### PR TITLE
Increase depth + time management

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,6 +26,7 @@ target_sources(Blocky PRIVATE
     src/moveGen.cpp
     src/search.cpp
     src/eval.cpp
+    src/timeman.cpp
     src/uci.cpp
 )
 

--- a/src/timeman.cpp
+++ b/src/timeman.cpp
@@ -1,0 +1,15 @@
+#include "timeman.hpp"
+#include <iostream>
+namespace TIMEMAN {
+    int timeToDepth(int ms) {
+        // these values are completely arbitrary and only serve to be used to found development
+        // for time management later on and prevent time outs for increasing depths
+        if (ms >= 1000000) {return 7;}
+        if (ms >= 500000) {return 6;}
+        if (ms >= 30000) {return 5;}
+        if (ms >= 2000) {return 4;}
+        if (ms >= 500) {return 3;}
+        if (ms >= 100) {return 2;}
+        return 1;
+    }
+} // namespace TIMEMAN

--- a/src/timeman.hpp
+++ b/src/timeman.hpp
@@ -1,0 +1,6 @@
+#pragma once
+
+namespace TIMEMAN {
+    const int INF_TIME = 1000000000;
+    int timeToDepth(int ms);
+} // namespace TIMEMAN

--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -22,7 +22,7 @@ namespace UCI {
         std::cout << "id name BLOCKY\n";
         std::cout << "id author BlockyTeam\n";
 
-        std::cout << "option name Depth type spin default 4 min 1 max 7\n";
+        std::cout << "option name Depth type spin default 5 min 1 max 7\n";
 
         std::cout << "uciok\n";
         return true;

--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -5,6 +5,7 @@
 #include <chrono>
 
 #include "uci.hpp"
+#include "timeman.hpp"
 #include "search.hpp"
 #include "inCheck.hpp"
 #include "board.hpp"
@@ -97,18 +98,27 @@ namespace UCI {
 
     void go(std::istringstream& input, Board& board) {
         std::string token;
+        int wtime = TIMEMAN::INF_TIME, btime = TIMEMAN::INF_TIME, allytime;
+        std::string param, value;
+        while (input >> param) {
+            input >> value;
+            if (param == "wtime") {wtime = stoi(value);}
+            else if (param == "btime") {btime = stoi(value);}
+        }   
+        allytime = board.isWhiteTurn ? wtime : btime;
+        int depthToUse = OPTIONS.depth < TIMEMAN::timeToDepth(allytime) ? OPTIONS.depth : TIMEMAN::timeToDepth(allytime);
 
         auto start = std::chrono::high_resolution_clock::now();
-        SEARCH::SearchInfo result = SEARCH::search(board, OPTIONS.depth);
+        SEARCH::SearchInfo result = SEARCH::search(board, depthToUse);
         auto end = std::chrono::high_resolution_clock::now();
         int64_t duration = std::chrono::duration_cast<std::chrono::microseconds>(end - start).count();
         
-        info(result, duration);
+        info(result, duration, depthToUse);
         std::cout << "bestmove " << result.move.toStr() << "\n";
     }
 
-    void info(SEARCH::SearchInfo searchResult, int64_t searchDuration) {
-        std::cout << "info depth " << OPTIONS.depth << ' ';
+    void info(SEARCH::SearchInfo searchResult, int64_t searchDuration, int depth) {
+        std::cout << "info depth " << depth << ' ';
         std::cout << "nodes " << searchResult.nodes << ' ';
         if (searchDuration != 0) {
             std::cout << "nps " << static_cast<int64_t>(searchResult.nodes) * 1000000 / searchDuration  << ' ';

--- a/src/uci.hpp
+++ b/src/uci.hpp
@@ -19,7 +19,7 @@ namespace UCI {
     void UCILOOP();
     Board position(std::istringstream& input);
     void go(std::istringstream& input, Board& board);
-    void info(SEARCH::SearchInfo searchResult, int64_t searchDuration);
+    void info(SEARCH::SearchInfo searchResult, int64_t searchDuration, int depth);
 
     void isready();
 

--- a/src/uci.hpp
+++ b/src/uci.hpp
@@ -8,7 +8,7 @@
 
 namespace UCI {
     struct UCIOPTIONS {
-        int depth = 4;
+        int depth = 5;
     };
 
     bool uci();


### PR DESCRIPTION
![image](https://github.com/knguy22/Blocky-Chess-Engine/assets/77951761/1bd36078-d48e-44e8-a784-4b96815e6c8e)

Depth 5 on its own loses games to timeout on 1 minute + 0.6 second increment, so I decided to implement a form of time management. The time management is definitely not ideal, though I don't expect to put too much focus on tuning it for the near future unless the time management algorithm becomes more advanced. I expect that to happen after iterative deepening is implemented.

The most important thing is that speedups to search without any loss of evaluation strength can now be tested for improvement in regular matches, as speedups take less time to find a best move for the same depth, meaning that more moves can be evaluated at the maximum depth before time management forces Blocky to use lower depths to conserve time left. 