### PR TITLE
use compiler optimizations gcc

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,4 +34,4 @@ target_include_directories(Blocky PRIVATE
     src
 )
 
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -O3")


### PR DESCRIPTION
![image](https://github.com/knguy22/Blocky-Chess-Engine/assets/77951761/04383b1b-2527-47b7-abf6-0d2fc93e6cab)

There's pretty much only speedups that can be seen here. I will do some testing just in case to see if the optimizations screwed anything up, but it's unlikely.