### PR TITLE
Redefine piece types

### DIFF
--- a/src/board.cpp
+++ b/src/board.cpp
@@ -75,6 +75,7 @@ Board::Board(std::string fenStr) {
     std::string token; 
     std::istringstream fenStream(fenStr);
 
+    std::fill(this->board.begin(), this->board.end(), EmptyPiece);
     fenStream >> token;
     int rank = 0, file = A;
     for (char& iter: token) {

--- a/src/board.cpp
+++ b/src/board.cpp
@@ -263,7 +263,9 @@ void Board::makeMove(BoardSquare pos1, BoardSquare pos2, pieceTypes promotionPie
     }
 
     // updates the material score of the board on capture
-    this->materialDifference -= pieceValues[targetPiece]; 
+    if (targetPiece != EmptyPiece) {
+        this->materialDifference -= pieceValues[targetPiece]; 
+    }
     // if nothing happened to the jumped pawn, disallow en passant
     this->pawnJumpedSquare = this->pawnJumpedSquare == oldPawnJumpedSquare ? BoardSquare() : this->pawnJumpedSquare;
     this->isIllegalPos = currKingInAttack(*this);

--- a/src/types.hpp
+++ b/src/types.hpp
@@ -4,11 +4,11 @@
 #include <unordered_map>
 
 constexpr int BOARD_SIZE = 64;
-constexpr int NUM_BITBOARDS = 15;
+constexpr int NUM_BITBOARDS = 14;
 
 enum fileVals {nullFile = -1, A, B, C, D, E, F, G, H};
 
-enum pieceTypes {nullPiece = -1, EmptyPiece,
+enum pieceTypes {nullPiece = -2, EmptyPiece,
                 WKing, WQueen, WBishop, WKnight, WRook, WPawn, 
                 BKing, BQueen, BBishop, BKnight, BRook, BPawn,
                 WHITE_PIECES, BLACK_PIECES};
@@ -35,7 +35,6 @@ enum castleRights {
 
 // indices are equal to the enumerated pieceTypes
 const static std::array<int, 13> pieceValues {
-    0,
      1000,  9,  3,  3,  5,  1, 
     -1000, -9, -3, -3, -5, -1,};
 


### PR DESCRIPTION
![image](https://github.com/knguy22/Blocky-Chess-Engine/assets/77951761/e084e41b-cde4-424e-b93f-e184da8b1e7b)

No change in strength.

Interestingly, there appears be a micro-optimization in the makeMove() method. Looking at startpos to depth 5:

**Main**
![image](https://github.com/knguy22/Blocky-Chess-Engine/assets/77951761/6b0536b0-fc29-460c-bc00-a310bda73771)

vs 

**This Branch**
![image](https://github.com/knguy22/Blocky-Chess-Engine/assets/77951761/7b1bbeed-f374-4cd9-82a5-346937fd5268)