### PR TITLE
Zobrist Hashing + 3 Fold Repetition

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,6 +20,7 @@ endif(MAKE_EXE)
 unset(MAKE_EXE CACHE)
 
 target_sources(Blocky PRIVATE
+    src/zobrist.cpp
     src/bitboard.cpp
     src/move.cpp
     src/board.cpp

--- a/src/board.cpp
+++ b/src/board.cpp
@@ -80,6 +80,7 @@ Board::Board(std::string fenStr) {
     std::istringstream fenStream(fenStr);
     this->zobristKeyHistory = {0ull}; // required for setPiece
 
+    std::fill(this->board.begin(), this->board.end(), EmptyPiece);
     fenStream >> token;
     int rank = 0, file = A;
     for (char& iter: token) {

--- a/src/board.cpp
+++ b/src/board.cpp
@@ -75,6 +75,7 @@ Board::Board(std::string fenStr) {
     std::string token; 
     std::istringstream fenStream(fenStr);
 
+    std::fill(this->board.begin(), this->board.end(), EmptyPiece);
     fenStream >> token;
     int rank = 0, file = A;
     for (char& iter: token) {

--- a/src/board.cpp
+++ b/src/board.cpp
@@ -251,7 +251,6 @@ void Board::makeMove(BoardSquare pos1, BoardSquare pos2, pieceTypes promotionPie
         int behindDirection = this->isWhiteTurn ? 1 : -1;
         this->pawnJumpedSquare = BoardSquare(pos2.rank + behindDirection, pos2.file);
         this->zobristKey ^= Zobrist::enPassKeys[pos2.file];
-        this->fiftyMoveRule = 0;
     }
     // promoting pawn
     else if (originPiece == allyPawn && pos2.rank == promotionRank) {
@@ -270,7 +269,6 @@ void Board::makeMove(BoardSquare pos1, BoardSquare pos2, pieceTypes promotionPie
         this->setPiece(pos1.rank, pos2.file, EmptyPiece);
         this->zobristKey ^= Zobrist::enPassKeys[pos2.file];
         this->pawnJumpedSquare = BoardSquare();
-        this->fiftyMoveRule = 0;
 
         if(this->isWhiteTurn)
             materialDifference++;

--- a/src/board.cpp
+++ b/src/board.cpp
@@ -195,7 +195,6 @@ void Board::makeMove(BoardSquare pos1, BoardSquare pos2, pieceTypes promotionPie
 
     BoardSquare oldPawnJumpedSquare = this->pawnJumpedSquare;
 
-    this->fiftyMoveRule++; // unless stated otherwise later on, increment the fifty move rule
     this->setPiece(pos1, EmptyPiece); // origin square should be cleared in all situations
     this->setPiece(pos2, originPiece); // pretty much all possible moves translates the original piece to pos 2
 
@@ -216,12 +215,10 @@ void Board::makeMove(BoardSquare pos1, BoardSquare pos2, pieceTypes promotionPie
         // doesn't check if pawn's original position is rank 2
         int behindDirection = this->isWhiteTurn ? 1 : -1;
         this->pawnJumpedSquare = BoardSquare(pos2.rank + behindDirection, pos2.file);
-        this->fiftyMoveRule = 0;
     }
     // promoting pawn
     else if (originPiece == allyPawn && pos2.rank == promotionRank) {
         this->setPiece(pos2, promotionPiece);
-        this->fiftyMoveRule = 0;
 
         //updates material score of the board on promotion
         if(this->isWhiteTurn) {
@@ -234,18 +231,19 @@ void Board::makeMove(BoardSquare pos1, BoardSquare pos2, pieceTypes promotionPie
     // en passant 
     else if (originPiece == allyPawn && pos2 == this->pawnJumpedSquare) {
         this->setPiece(pos1.rank, pos2.file, EmptyPiece);
-        this->fiftyMoveRule = 0;
 
         if(this->isWhiteTurn)
             materialDifference++;
         else
             materialDifference--;
+    }
 
+    // reset fifty move rule on captures or pawn moves
+    if (targetPiece != EmptyPiece || originPiece == allyPawn) {
+        this->fiftyMoveRule = 0;
     }
     else {
-        if (targetPiece != EmptyPiece || originPiece == allyPawn) {
-            this->fiftyMoveRule = 0;
-        }
+        this->fiftyMoveRule++;
     }
 
     // if either your allyRook is moved or an enemyRook is captured, modify castling rights

--- a/src/board.cpp
+++ b/src/board.cpp
@@ -7,6 +7,7 @@
 #include "board.hpp"
 #include "move.hpp"
 #include "bitboard.hpp"
+#include "zobrist.hpp"
 #include "types.hpp"
 
 // Used for debugging and testing
@@ -44,6 +45,8 @@ Board::Board() {
 
     this->pieceSets[WHITE_PIECES] = 0xFFFF000000000000ull;
     this->pieceSets[BLACK_PIECES] = 0x000000000000FFFFull;
+
+    this->initZobristKey();
 }
 
 // Used for debugging and testing
@@ -67,6 +70,7 @@ Board::Board(std::array<pieceTypes, BOARD_SIZE> a_board, bool a_isWhiteTurn,
             this->pieceSets[BLACK_PIECES] |= makeBitboardFromArray(this->board, i);
         }
     }
+    this->initZobristKey();
 }
 
 // Used in UCI
@@ -74,6 +78,7 @@ Board::Board(std::string fenStr) {
     this->materialDifference = 0;
     std::string token; 
     std::istringstream fenStream(fenStr);
+    this->zobristKeyHistory = {0ull}; // required for setPiece
 
     fenStream >> token;
     int rank = 0, file = A;
@@ -112,6 +117,7 @@ Board::Board(std::string fenStr) {
 
     this->isIllegalPos = false; // it is up to the UCI gui to not give illegal positions
 
+    this->initZobristKey();
     // Board doesn't use Fullmove counter
 }
 
@@ -164,6 +170,35 @@ std::string Board::toFen() {
     return fenStr;
 }
 
+// assumes no move history
+void Board::initZobristKey() {
+    this->zobristKey = 0ull;
+    Zobrist::initKeys();
+
+    // pieces on board
+    for (size_t i = 0; i < BOARD_SIZE; i++) {
+        pieceTypes currPiece = this->board[i];
+        if (currPiece == EmptyPiece) {continue;}
+        this->zobristKey ^= Zobrist::pieceKeys[currPiece][i];
+    }
+    // castling
+    for (size_t i = 0; i < 4; i++) {
+        if (this->castlingRights & 1ull << i) {
+            this->zobristKey ^= Zobrist::castlingKeys[i];
+        }
+    }
+    // en passant
+    if (this->pawnJumpedSquare != BoardSquare()) {
+        this->zobristKey ^= Zobrist::enPassKeys[this->pawnJumpedSquare.file];
+    }
+    // color to move
+    if (!this->isWhiteTurn) {
+        this->zobristKey ^= Zobrist::isBlackKey;
+    }
+    this->zobristKeyHistory = {this->zobristKey}; // synchronize history and current key
+}
+
+
 bool notInRange(int var) {return var < 0 || var > 7;}
 void Board::makeMove(BoardSquare pos1, BoardSquare pos2, pieceTypes promotionPiece) {
     if (notInRange(pos1.rank) || notInRange(pos1.file) || notInRange(pos2.file) || notInRange(pos2.rank)) {
@@ -193,6 +228,7 @@ void Board::makeMove(BoardSquare pos1, BoardSquare pos2, pieceTypes promotionPie
     ));
 
     BoardSquare oldPawnJumpedSquare = this->pawnJumpedSquare;
+    castleRights oldCastlingRights = this->castlingRights;
 
     this->setPiece(pos1, EmptyPiece); // origin square should be cleared in all situations
     this->setPiece(pos2, originPiece); // pretty much all possible moves translates the original piece to pos 2
@@ -204,16 +240,18 @@ void Board::makeMove(BoardSquare pos1, BoardSquare pos2, pieceTypes promotionPie
         fileVals rookFile = kingFileDirection == 1 ? H : A;
         this->setPiece(pos1.rank, pos1.file + kingFileDirection, allyRook);
         this->setPiece(pos1.rank, rookFile, EmptyPiece);
-        this->castlingRights &= allyKing == WKing ? B_Castle : W_Castle;
+        this->castlingRights &= this->isWhiteTurn ? B_Castle : W_Castle;
     }
     else if (originPiece == allyKing) {
-        this->castlingRights &= allyKing == WKing ? B_Castle : W_Castle;
+        this->castlingRights &= this->isWhiteTurn ? B_Castle : W_Castle;
     }
     // jumping pawn
     else if (originPiece == allyPawn && pos2.rank == pos1.rank + pawnJumpDirection) { 
         // doesn't check if pawn's original position is rank 2
         int behindDirection = this->isWhiteTurn ? 1 : -1;
         this->pawnJumpedSquare = BoardSquare(pos2.rank + behindDirection, pos2.file);
+        this->zobristKey ^= Zobrist::enPassKeys[pos2.file];
+        this->fiftyMoveRule = 0;
     }
     // promoting pawn
     else if (originPiece == allyPawn && pos2.rank == promotionRank) {
@@ -230,6 +268,9 @@ void Board::makeMove(BoardSquare pos1, BoardSquare pos2, pieceTypes promotionPie
     // en passant 
     else if (originPiece == allyPawn && pos2 == this->pawnJumpedSquare) {
         this->setPiece(pos1.rank, pos2.file, EmptyPiece);
+        this->zobristKey ^= Zobrist::enPassKeys[pos2.file];
+        this->pawnJumpedSquare = BoardSquare();
+        this->fiftyMoveRule = 0;
 
         if(this->isWhiteTurn)
             materialDifference++;
@@ -259,6 +300,14 @@ void Board::makeMove(BoardSquare pos1, BoardSquare pos2, pieceTypes promotionPie
         this->castlingRights &= pos2 == BoardSquare("a8") ? NOT_B_OOO : All_Castle;
     }
 
+    // update zobrist key for changed castling rights; castling rights can only decrease in chess
+    for (int i = 0; i < 4; i++) {
+        int mask = 1ull << i;
+        if ((oldCastlingRights & mask) && !(this->castlingRights & mask)) {
+            this->zobristKey ^= Zobrist::castlingKeys[i];
+        }
+    }
+
     // updates the material score of the board on capture
     if (targetPiece != EmptyPiece) {
         this->materialDifference -= pieceValues[targetPiece]; 
@@ -269,6 +318,10 @@ void Board::makeMove(BoardSquare pos1, BoardSquare pos2, pieceTypes promotionPie
 
     // after finalizing move logic, now switch turns
     this->isWhiteTurn = !this->isWhiteTurn; 
+    this->zobristKey ^= Zobrist::isBlackKey;
+
+    // update history to include curr key
+    this->zobristKeyHistory.push_back(this->zobristKey);
 }
 
 void Board::makeMove(BoardMove move) {
@@ -310,6 +363,8 @@ void Board::undoMove() {
     this->isIllegalPos = false;
 
     this->moveHistory.pop_back();
+    this->zobristKeyHistory.pop_back();
+    this->zobristKey = zobristKeyHistory.back();
 }
 
 pieceTypes Board::getPiece(int rank, int file) const {
@@ -323,6 +378,7 @@ pieceTypes Board::getPiece(BoardSquare square) const{
     return this->getPiece(square.rank, square.file);
 }
 
+// handles board, pieceSets, and zobristKey (not including en passant and castling)
 void Board::setPiece(int rank, int file, pieceTypes currPiece) {
     int square = rank * 8 + file;
     uint64_t setSquare = (1ull << square);
@@ -335,11 +391,13 @@ void Board::setPiece(int rank, int file, pieceTypes currPiece) {
         pieceTypes originColor = originPiece < BKing ? WHITE_PIECES : BLACK_PIECES;
         this->pieceSets[originColor] &= clearSquare;
         this->pieceSets[originPiece] &= clearSquare;
+        this->zobristKey ^= Zobrist::pieceKeys[originPiece][square];
     }
     if (currPiece != EmptyPiece) {
         pieceTypes currColor = currPiece < BKing ? WHITE_PIECES : BLACK_PIECES;
         this->pieceSets[currColor] ^= setSquare;
         this->pieceSets[currPiece] ^= setSquare;
+        this->zobristKey ^= Zobrist::pieceKeys[currPiece][square];
     }
 }
 
@@ -348,7 +406,7 @@ void Board::setPiece(BoardSquare square, pieceTypes currPiece) {
 }
 
 bool operator==(const Board& lhs, const Board& rhs) {
-    return  (lhs.board == rhs.board) && (lhs.pieceSets == rhs.pieceSets);
+    return  (lhs.board == rhs.board) && (lhs.pieceSets == rhs.pieceSets) && (lhs.zobristKeyHistory == rhs.zobristKeyHistory);
 }
 
 bool operator<(const Board& lhs, const Board& rhs) {
@@ -378,6 +436,7 @@ std::ostream& operator<<(std::ostream& os, const Board& target) {
     os << "isIllegalPos: " << target.isIllegalPos << "\n";
     os << "isWhiteTurn: " << target.isWhiteTurn << "\n";
     os << "50MoveRule: " << target.fiftyMoveRule << "\n";
+    os << "ZobristKey: " << target.zobristKey << "\n";
     return os;
 }
 

--- a/src/board.cpp
+++ b/src/board.cpp
@@ -75,7 +75,6 @@ Board::Board(std::string fenStr) {
     std::string token; 
     std::istringstream fenStream(fenStr);
 
-    std::fill(this->board.begin(), this->board.end(), EmptyPiece);
     fenStream >> token;
     int rank = 0, file = A;
     for (char& iter: token) {

--- a/src/board.hpp
+++ b/src/board.hpp
@@ -34,6 +34,7 @@ struct Board {
     // for production
     Board(std::string fenStr);
     std::string toFen();
+    void initZobristKey();
     
     void makeMove(BoardSquare pos1, BoardSquare pos2, pieceTypes promotionPiece = nullPiece);
     void makeMove(BoardMove move);
@@ -50,6 +51,8 @@ struct Board {
 
     std::array<uint64_t, NUM_BITBOARDS> pieceSets = {0ull};
     std::array<pieceTypes, BOARD_SIZE> board = {EmptyPiece};
+
+    uint64_t zobristKey; // zobristKeyHistory also contains zobristKey
     bool isWhiteTurn;
     castleRights castlingRights; // bitwise castling rights tracker
     int fiftyMoveRule;
@@ -58,6 +61,7 @@ struct Board {
     int materialDifference; // updates on capture or promotion, so the eval doesn't have to calculate for each board, positive is white advantage
 
     std::vector<BoardState> moveHistory;
+    std::vector<uint64_t> zobristKeyHistory;
 };
 
 castleRights castleRightsBit(BoardSquare finalKingPos, bool isWhiteTurn);

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1,5 +1,6 @@
 #include <vector>
 #include <utility>
+#include <iostream>
 
 #include "search.hpp"
 #include "eval.hpp"
@@ -16,15 +17,26 @@ namespace Search {
         SearchInfo result;
         result.nodes = 1;
 
-        // check for game ending by draw or checkmate
+        // fifty move rule
         if (board.fiftyMoveRule == 100) {
             result.value = 0;
             return result;
         }
+        // three-fold repetition
+        std::vector<uint64_t> currKeyHistory = board.zobristKeyHistory;
+        std::sort(currKeyHistory.begin(), currKeyHistory.end());
+        auto lBound = std::lower_bound(currKeyHistory.begin(), currKeyHistory.end(), board.zobristKey);
+        auto rBound = std::upper_bound(currKeyHistory.begin(), currKeyHistory.end(), board.zobristKey);
+        if (distance(lBound, rBound) == 3) {
+            result.value = 0;
+            return result;
+        }
+        // max depth reached
         if (depthLeft == 0) {
             result.value = eval(board);
             return result;
         }
+        // checkmate or stalemate
         std::vector<BoardMove> moves = MOVEGEN::moveGenerator(board);
         if (moves.size() == 0) {
             if (currKingInAttack(board)) {

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -17,7 +17,7 @@ namespace Search {
         result.nodes = 1;
 
         // check for game ending by draw or checkmate
-        if (board.fiftyMoveRule >= 50) {
+        if (board.fiftyMoveRule == 100) {
             result.value = 0;
             return result;
         }

--- a/src/types.hpp
+++ b/src/types.hpp
@@ -9,7 +9,7 @@ constexpr int NUM_PIECE_TYPES = 12;
 
 enum fileVals {nullFile = -1, A, B, C, D, E, F, G, H};
 
-enum pieceTypes {nullPiece = -1, EmptyPiece,
+enum pieceTypes {nullPiece = -2, EmptyPiece,
                 WKing, WQueen, WBishop, WKnight, WRook, WPawn, 
                 BKing, BQueen, BBishop, BKnight, BRook, BPawn,
                 WHITE_PIECES, BLACK_PIECES};
@@ -36,7 +36,6 @@ enum castleRights {
 
 // indices are equal to the enumerated pieceTypes
 const static std::array<int, 13> pieceValues {
-    0,
      1000,  9,  3,  3,  5,  1, 
     -1000, -9, -3, -3, -5, -1,};
 

--- a/src/types.hpp
+++ b/src/types.hpp
@@ -4,7 +4,8 @@
 #include <unordered_map>
 
 constexpr int BOARD_SIZE = 64;
-constexpr int NUM_BITBOARDS = 15;
+constexpr int NUM_BITBOARDS = 14;
+constexpr int NUM_PIECE_TYPES = 12;
 
 enum fileVals {nullFile = -1, A, B, C, D, E, F, G, H};
 

--- a/src/types.hpp
+++ b/src/types.hpp
@@ -4,11 +4,11 @@
 #include <unordered_map>
 
 constexpr int BOARD_SIZE = 64;
-constexpr int NUM_BITBOARDS = 14;
+constexpr int NUM_BITBOARDS = 15;
 
 enum fileVals {nullFile = -1, A, B, C, D, E, F, G, H};
 
-enum pieceTypes {nullPiece = -2, EmptyPiece,
+enum pieceTypes {nullPiece = -1, EmptyPiece,
                 WKing, WQueen, WBishop, WKnight, WRook, WPawn, 
                 BKing, BQueen, BBishop, BKnight, BRook, BPawn,
                 WHITE_PIECES, BLACK_PIECES};
@@ -35,6 +35,7 @@ enum castleRights {
 
 // indices are equal to the enumerated pieceTypes
 const static std::array<int, 13> pieceValues {
+    0,
      1000,  9,  3,  3,  5,  1, 
     -1000, -9, -3, -3, -5, -1,};
 

--- a/src/types.hpp
+++ b/src/types.hpp
@@ -4,11 +4,11 @@
 #include <unordered_map>
 
 constexpr int BOARD_SIZE = 64;
-constexpr int NUM_BITBOARDS = 15;
+constexpr int NUM_BITBOARDS = 14;
 
 enum fileVals {nullFile = -1, A, B, C, D, E, F, G, H};
 
-enum pieceTypes {nullPiece = -1, EmptyPiece,
+enum pieceTypes {nullPiece = -2, EmptyPiece,
                 WKing, WQueen, WBishop, WKnight, WRook, WPawn, 
                 BKing, BQueen, BBishop, BKnight, BRook, BPawn,
                 WHITE_PIECES, BLACK_PIECES};
@@ -35,7 +35,6 @@ enum castleRights {
 
 // indices are equal to the enumerated pieceTypes
 const static std::array<int, 13> pieceValues {
-    0,
      1000,  9,  3,  3,  5,  1, 
     -1000, -9, -3, -3, -5, -1,};
 

--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -91,6 +91,15 @@ namespace Uci {
         if (token != "moves") {return currBoard;}
         while (input >> token) {
             currBoard.makeMove(BoardMove(token, currBoard.isWhiteTurn));
+            // if a capture or castling rights change, clear move history since
+            // 3fold repetition or 50 move rule will be reset
+            // this makes things faster
+            if (currBoard.moveHistory.back().targetPiece != EmptyPiece ||
+                currBoard.castlingRights != currBoard.moveHistory.back().castlingRights) {
+                currBoard.moveHistory.clear();
+                currBoard.zobristKeyHistory.clear();
+                currBoard.zobristKeyHistory.push_back(currBoard.zobristKey);
+            }
         }
         return currBoard;
     }

--- a/src/zobrist.cpp
+++ b/src/zobrist.cpp
@@ -1,0 +1,49 @@
+#include <array>
+#include <cstdint>
+#include <iostream>
+
+#include "zobrist.hpp"
+#include "types.hpp"
+
+namespace Zobrist {
+    // global variables definition
+    std::array<uint64_t, 4> seed;
+    std::array<std::array<uint64_t, BOARD_SIZE>, NUM_PIECE_TYPES> pieceKeys;
+    std::array<uint64_t, 4> castlingKeys;
+    std::array<uint64_t, 8> enPassKeys;
+    uint64_t isBlackKey;
+
+    // xoshiro256++
+    // https://prng.di.unimi.it/xoshiro256plusplus.c
+    uint64_t rand64() {
+        const uint64_t result = rotl(seed[0] + seed[3], 23) + seed[0];
+        const uint64_t t = seed[1] << 17;
+        seed[2] ^= seed[0];
+        seed[3] ^= seed[1];
+        seed[1] ^= seed[2];
+        seed[0] ^= seed[3];
+        seed[2] ^= t;
+        seed[3] = rotl(seed[3], 45);
+        return result;
+    }
+
+    // zobrist hashing
+    void initKeys() {
+        // 16 different 16 bit integers were collected from random.org and assembled together to form the 256 bit seed
+        // feel free to experiment with different ones
+        seed = {0x360BAFF383999633ull, 0x68EE16F8479F8123ull, 0xA89ADF4551B3B25Bull, 0x4887B5A003B21D40ull};
+        for (auto& piece: pieceKeys) {
+            for (auto& square: piece) {
+                square = rand64();
+            }
+        }
+        for (auto& key: castlingKeys) {
+            key = rand64();
+        }
+        for (auto& key: enPassKeys) {
+            key = rand64();
+        }
+        isBlackKey = rand64();
+    }
+} // namespace Zobrist
+

--- a/src/zobrist.hpp
+++ b/src/zobrist.hpp
@@ -1,0 +1,20 @@
+#pragma once
+
+#include <array>
+#include <cstdint>
+
+#include "types.hpp"
+
+namespace Zobrist {
+    extern std::array<uint64_t, 4> seed;
+    static inline uint64_t rotl(const uint64_t x, int k) {
+        return (x << k) | (x >> (64 - k));
+    }
+    uint64_t rand64();
+
+    extern std::array<std::array<uint64_t, BOARD_SIZE>, NUM_PIECE_TYPES> pieceKeys;
+    extern std::array<uint64_t, 4> castlingKeys;
+    extern std::array<uint64_t, 8> enPassKeys;
+    extern uint64_t isBlackKey;
+    void initKeys();
+} // namespace Zobrist

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -24,6 +24,7 @@ add_executable(
     testBoard.cpp
     testMoveGen.cpp
     testSearch.cpp
+    ../src/zobrist.cpp
     ../src/bitboard.cpp
     ../src/move.cpp
     ../src/board.cpp

--- a/tests/testBoard.cpp
+++ b/tests/testBoard.cpp
@@ -570,7 +570,7 @@ TEST(BoardTest, BoardMoveConstructorMovedKing) {
     };
     Board board(boardArr, true);
     BoardSquare pos1 = BoardSquare(7, E);
-    BoardSquare pos2 = BoardSquare(6, D);
+    BoardSquare pos2 = BoardSquare(6, E);
     board.makeMove(pos1, pos2);
 
     EXPECT_EQ(board.isWhiteTurn, false);

--- a/tests/testBoard.cpp
+++ b/tests/testBoard.cpp
@@ -1,4 +1,5 @@
 #include "board.hpp"
+#include "zobrist.hpp"
 
 #include <gtest/gtest.h>
 #include <string>
@@ -82,6 +83,9 @@ TEST(BoardTest, fenConstructorDefault) {
 
     EXPECT_EQ(fenBoard.pieceSets, defaultBoard.pieceSets);
     EXPECT_EQ(fenBoard.board, defaultBoard.board);
+    EXPECT_EQ(fenBoard.zobristKey, defaultBoard.zobristKey);
+    EXPECT_NE(fenBoard.zobristKey, 0);
+    EXPECT_EQ(fenBoard.zobristKeyHistory.back(), fenBoard.zobristKey);
     EXPECT_EQ(fenBoard.isWhiteTurn, defaultBoard.isWhiteTurn);
     EXPECT_EQ(fenBoard.castlingRights, defaultBoard.castlingRights);
     EXPECT_EQ(fenBoard.pawnJumpedSquare, defaultBoard.pawnJumpedSquare);
@@ -89,12 +93,19 @@ TEST(BoardTest, fenConstructorDefault) {
 }
 
 TEST(BoardTest, fenConstructorEnPassantSquare) {
+    std::cout << "fenbegin\n";
     Board fenBoard("rnbqkbnr/pppppppp/8/8/4P3/8/PPPP1PPP/RNBQKBNR b KQkq e3 0 1");
+    std::cout << "fenEnd\n";
+    std::cout << "makemoveBegin\n";
     Board moveBoard;
     moveBoard.makeMove(BoardMove("e2e4", moveBoard.isWhiteTurn));
+    std::cout << "makemoveEnd\n";
     
     EXPECT_EQ(fenBoard.pieceSets, moveBoard.pieceSets);
     EXPECT_EQ(fenBoard.board, moveBoard.board);
+    EXPECT_EQ(fenBoard.zobristKey, moveBoard.zobristKey);
+    EXPECT_NE(fenBoard.zobristKey, 0);
+    EXPECT_EQ(fenBoard.zobristKeyHistory.back(), fenBoard.zobristKey);
     EXPECT_EQ(fenBoard.isWhiteTurn, moveBoard.isWhiteTurn);
     EXPECT_EQ(fenBoard.castlingRights, moveBoard.castlingRights);
     EXPECT_EQ(fenBoard.pawnJumpedSquare, moveBoard.pawnJumpedSquare);
@@ -115,6 +126,9 @@ TEST(BoardTest, fenConstructorEnPassantCastle) {
 
     EXPECT_EQ(fenBoard.pieceSets, moveBoard.pieceSets);
     EXPECT_EQ(fenBoard.board, moveBoard.board);
+    EXPECT_EQ(fenBoard.zobristKey, moveBoard.zobristKey);
+    EXPECT_NE(fenBoard.zobristKey, 0);
+    EXPECT_EQ(fenBoard.zobristKeyHistory.back(), fenBoard.zobristKey);
     EXPECT_EQ(fenBoard.isWhiteTurn, moveBoard.isWhiteTurn);
     EXPECT_EQ(fenBoard.castlingRights, moveBoard.castlingRights);
     EXPECT_EQ(fenBoard.pawnJumpedSquare, moveBoard.pawnJumpedSquare);
@@ -785,4 +799,29 @@ TEST(BoardTest, BoardMoveConstructorCastleRightsRook3) {
     Board board("7r/1k4P1/1n6/B7/P4P1p/7P/4NK2/1R5R b - - 0 44");
     board.makeMove(BoardMove("h8g8", board.isWhiteTurn));
     EXPECT_EQ(board.castlingRights, noCastle);
+}
+
+TEST(BoardTest, undoMove) {
+    // ruy lopez
+    Board defaultBoard, moveBoard;
+    moveBoard.makeMove(BoardMove("e2e4", moveBoard.isWhiteTurn));
+    moveBoard.makeMove(BoardMove("e7e5", moveBoard.isWhiteTurn));
+    moveBoard.makeMove(BoardMove("g1f3", moveBoard.isWhiteTurn));
+    moveBoard.makeMove(BoardMove("b8c6", moveBoard.isWhiteTurn));
+    moveBoard.makeMove(BoardMove("f1b5", moveBoard.isWhiteTurn));
+    moveBoard.makeMove(BoardMove("g8f6", moveBoard.isWhiteTurn));
+    moveBoard.makeMove(BoardMove("e1g1", moveBoard.isWhiteTurn));
+    for (int i = 0; i < 7; i++) {
+        moveBoard.undoMove();
+    }
+
+    EXPECT_EQ(defaultBoard.pieceSets, moveBoard.pieceSets);
+    EXPECT_EQ(defaultBoard.board, moveBoard.board);
+    EXPECT_EQ(defaultBoard.zobristKey, moveBoard.zobristKey);
+    EXPECT_NE(defaultBoard.zobristKey, 0);
+    EXPECT_EQ(defaultBoard.zobristKeyHistory.back(), defaultBoard.zobristKey);
+    EXPECT_EQ(defaultBoard.isWhiteTurn, moveBoard.isWhiteTurn);
+    EXPECT_EQ(defaultBoard.castlingRights, moveBoard.castlingRights);
+    EXPECT_EQ(defaultBoard.pawnJumpedSquare, moveBoard.pawnJumpedSquare);
+    EXPECT_EQ(defaultBoard.fiftyMoveRule, moveBoard.fiftyMoveRule);
 }


### PR DESCRIPTION
Forgive me for the messy commit history. I was trying out rebasing and did some mistakes. All real commits start at "zobrist hashing definitions"

The main things to take away from this is that all board states are now hashable and have their hashes updated incrementally. This can be used to do a variety of different things including below.

3 Fold Repetition is checked for by having move history contained in a vector during search. Then, it is sorted, and checked to see if three board hashes are in a row. If so, then 3 boards have been repeated on the board, resulting in a draw.