### PR TITLE
Give Bounds Checking Responsibility to Move Generation

### DIFF
--- a/src/board.cpp
+++ b/src/board.cpp
@@ -199,14 +199,8 @@ void Board::initZobristKey() {
     this->zobristKeyHistory = {this->zobristKey}; // synchronize history and current key
 }
 
-
-bool notInRange(int var) {return var < 0 || var > 7;}
+// makeMove will not check if the move is invalid
 void Board::makeMove(BoardSquare pos1, BoardSquare pos2, pieceTypes promotionPiece) {
-    if (notInRange(pos1.rank) || notInRange(pos1.file) || notInRange(pos2.file) || notInRange(pos2.rank)) {
-        this->isIllegalPos = true;
-        return;
-    }
-
     // allies haven't made a move yet
     pieceTypes allyKing = this->isWhiteTurn ? WKing : BKing;
     pieceTypes allyRook = this->isWhiteTurn ? WRook : BRook;
@@ -330,6 +324,7 @@ void Board::makeMove(BoardSquare pos1, BoardSquare pos2, pieceTypes promotionPie
     this->zobristKeyHistory.push_back(this->zobristKey);
 }
 
+// makeMove will not check if the move is invalid
 void Board::makeMove(BoardMove move) {
     this->makeMove(move.pos1, move.pos2, move.promotionPiece);
 }
@@ -373,13 +368,12 @@ void Board::undoMove() {
     this->zobristKey = zobristKeyHistory.back();
 }
 
+// getPiece is not responsible for bounds checking
 pieceTypes Board::getPiece(int rank, int file) const {
-    if (rank < 0 || rank > 7 || file < A || file > H) {
-        return nullPiece;
-    }
     return this->board[rank * 8 + file];
 }
 
+// getPiece is not responsible for bounds checking
 pieceTypes Board::getPiece(BoardSquare square) const{
     return this->getPiece(square.rank, square.file);
 }

--- a/src/board.cpp
+++ b/src/board.cpp
@@ -387,7 +387,7 @@ void Board::setPiece(int rank, int file, pieceTypes currPiece) {
     pieceTypes originPiece = this->getPiece(rank, file);
     this->board[square] = currPiece;
     
-    if (originPiece != nullPiece && originPiece != EmptyPiece) {
+    if (originPiece != EmptyPiece) {
         pieceTypes originColor = originPiece < BKing ? WHITE_PIECES : BLACK_PIECES;
         this->pieceSets[originColor] &= clearSquare;
         this->pieceSets[originPiece] &= clearSquare;

--- a/src/board.hpp
+++ b/src/board.hpp
@@ -65,7 +65,6 @@ struct Board {
 };
 
 castleRights castleRightsBit(BoardSquare finalKingPos, bool isWhiteTurn);
-bool notInRange(int var);
 bool currKingInAttack(Board& board);
 
 // for debugging

--- a/src/move.cpp
+++ b/src/move.cpp
@@ -25,6 +25,10 @@ std::string BoardSquare::toStr() {
     return move.str();
 }
 
+bool BoardSquare::isValid() const {
+    return this->rank >= 0 && this->file >= 0 && this->rank <= 7 && this->file <= 7;
+}
+
 bool operator==(const BoardSquare& lhs, const BoardSquare& rhs) {
     return (lhs.rank == rhs.rank) && (lhs.file == rhs.file);
 }
@@ -116,6 +120,10 @@ std::string BoardMove::toStr() const{
     move << this->pos2;
     move << pp;
     return move.str();
+}
+
+bool BoardMove::isValid() const {
+    return this->pos1.isValid() && this->pos2.isValid();
 }
 
 std::ostream& operator<<(std::ostream& os, const BoardMove& target) {

--- a/src/move.hpp
+++ b/src/move.hpp
@@ -11,6 +11,7 @@ struct BoardSquare {
     BoardSquare(std::string input);
     std::string toStr();
     int toSquare();
+    bool isValid() const;
 
     friend bool operator==(const BoardSquare& lhs, const BoardSquare& rhs);
     friend bool operator!=(const BoardSquare& lhs, const BoardSquare& rhs);
@@ -28,6 +29,7 @@ struct BoardMove {
         pos1(a_pos1), pos2(a_pos2), promotionPiece(a_promotionPiece) {}; 
     BoardMove(std::string input, bool isWhiteTurn);
     std::string toStr() const;
+    bool isValid() const;
 
     friend std::ostream& operator<<(std::ostream& os, const BoardMove& target);
     friend bool operator==(const BoardMove& lhs, const BoardMove& rhs);

--- a/src/moveGen.cpp
+++ b/src/moveGen.cpp
@@ -94,7 +94,7 @@ namespace MOVEGEN {
 
         BoardSquare square = BoardSquare(pawn.rank + pawnDirection, pawn.file + fileDirection);
         // regular capture
-        if (!isFriendlyPiece(currBoard, square) && currBoard.getPiece(square) != EmptyPiece && currBoard.getPiece(square) != nullPiece) {
+        if (square.isValid() && !isFriendlyPiece(currBoard, square) && currBoard.getPiece(square) != EmptyPiece) {
             pawnMoves.push_back(square);
         }
         // en passant
@@ -119,7 +119,7 @@ namespace MOVEGEN {
                 BoardSquare(currRank + 1, currFile + 2),
             };
             for (BoardSquare square: potentialMoves) {
-                if (!isFriendlyPiece(currBoard, square) && currBoard.getPiece(square) != nullPiece) {
+                if (square.isValid() && !isFriendlyPiece(currBoard, square)) {
                     knightMoves.push_back(square);
                 }
             }
@@ -198,7 +198,7 @@ namespace MOVEGEN {
             };
             // regular movements
             for (BoardSquare square: potentialAdjacentMoves) {
-                if (!isFriendlyPiece(currBoard, square) && currBoard.getPiece(square) != nullPiece) {
+                if (square.isValid() && !isFriendlyPiece(currBoard, square)) {
                     kingMoves.push_back(square);
                 }
             }

--- a/tests/testBoard.cpp
+++ b/tests/testBoard.cpp
@@ -25,30 +25,6 @@ TEST(BoardTest, getPieceValidSquare3) {
     EXPECT_EQ(getPieceResult, WPawn);
 }
 
-TEST(BoardTest, getPieceInvalidSquare1) {
-    Board defaultBoard;
-    BoardSquare square = BoardSquare(-1, A);
-    ASSERT_EQ(defaultBoard.getPiece(square), nullPiece);
-}
-
-TEST(BoardTest, getPieceInvalidSquare2) {
-    Board defaultBoard;
-    BoardSquare square = BoardSquare(8, A);
-    ASSERT_EQ(defaultBoard.getPiece(square), nullPiece);
-}
-
-TEST(BoardTest, getPieceInvalidSquare3) {
-    Board defaultBoard;
-    BoardSquare square = BoardSquare(0, -1);
-    ASSERT_EQ(defaultBoard.getPiece(square), nullPiece);
-}
-
-TEST(BoardTest, getPieceInvalidSquare4) {
-    Board defaultBoard;
-    BoardSquare square = BoardSquare(0, 8);
-    ASSERT_EQ(defaultBoard.getPiece(square), nullPiece);
-}
-
 TEST(BoardTest, boardSquareStrConstructor) {
     BoardSquare square = BoardSquare("a8");
     EXPECT_EQ(square.rank, 0);


### PR DESCRIPTION
I saw that there was some redundant bounds checking in moveGenerator and board, so I decided to clean those up a bit. Even though there were indeed some very minor speed increases, the main point was to remove redundant code. 

Board is no longer responsible for checking for moves to be in bounds, as it should be. After all, it already doesn't check other stuff like if pieces are in between the rook and king for castling. MoveGenerator now uses the inValid() method instead of getPiece() for bounds checking.