### PR TITLE
Redefine search

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -11,6 +11,7 @@ namespace Search {
     Search::Search(Board board) {
         this->board = board;
         this->nodes = 0;
+        this->depth = 0;
     }
 
     Info Search::search(int depth) {
@@ -18,6 +19,8 @@ namespace Search {
         Node root = this->alphaBeta(MIN_ALPHA, MAX_BETA, depth, 0);
 
         result.nodes = this->nodes;
+        result.depth = this->depth;
+        
         result.eval = root.eval;
         result.move = root.move;
         if (root.eval > MAX_BETA - 100) {
@@ -32,6 +35,7 @@ namespace Search {
     Node Search::alphaBeta(int alpha, int beta, int depthLeft, int distanceFromRoot) {
         Node result;
         this->nodes++;
+        this->depth = distanceFromRoot > this->depth ? distanceFromRoot : this->depth;
 
         // fifty move rule
         if (this->board.fiftyMoveRule == 100) {

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -8,43 +8,49 @@
 #include "board.hpp"
 
 namespace Search {
-    SearchInfo search(Board& board, int depth) {
-        auto result = alphaBeta(board, MIN_ALPHA, MAX_BETA, depth, 0);
+    Search::Search(Board board) {
+        this->board = board;
+        this->nodes = 0;
+    }
+
+    SearchInfo Search::search(int depth) {
+        SearchInfo result = this->alphaBeta(MIN_ALPHA, MAX_BETA, depth, 0);
+        result.nodes = this->nodes;
         return result;
     }
 
-    SearchInfo alphaBeta(Board& board, int alpha, int beta, int depthLeft, int distanceFromRoot) {
+    SearchInfo Search::alphaBeta(int alpha, int beta, int depthLeft, int distanceFromRoot) {
         SearchInfo result;
-        result.nodes = 1;
+        this->nodes++;
 
         // fifty move rule
-        if (board.fiftyMoveRule == 100) {
-            result.value = 0;
+        if (this->board.fiftyMoveRule == 100) {
+            result.eval = 0;
             return result;
         }
         // three-fold repetition
-        std::vector<uint64_t> currKeyHistory = board.zobristKeyHistory;
+        std::vector<uint64_t> currKeyHistory = this->board.zobristKeyHistory;
         std::sort(currKeyHistory.begin(), currKeyHistory.end());
-        auto lBound = std::lower_bound(currKeyHistory.begin(), currKeyHistory.end(), board.zobristKey);
-        auto rBound = std::upper_bound(currKeyHistory.begin(), currKeyHistory.end(), board.zobristKey);
+        auto lBound = std::lower_bound(currKeyHistory.begin(), currKeyHistory.end(), this->board.zobristKey);
+        auto rBound = std::upper_bound(currKeyHistory.begin(), currKeyHistory.end(), this->board.zobristKey);
         if (distance(lBound, rBound) == 3) {
-            result.value = 0;
+            result.eval = 0;
             return result;
         }
         // max depth reached
         if (depthLeft == 0) {
-            result.value = eval(board);
+            result.eval = eval(this->board);
             return result;
         }
         // checkmate or stalemate
-        std::vector<BoardMove> moves = MOVEGEN::moveGenerator(board);
+        std::vector<BoardMove> moves = MOVEGEN::moveGenerator(this->board);
         if (moves.size() == 0) {
             if (currKingInAttack(board)) {
-                result.value = MIN_ALPHA + distanceFromRoot;
+                result.eval = MIN_ALPHA + distanceFromRoot;
                 result.mateIn = distanceFromRoot;
             }
             else {
-                result.value = 0;
+                result.eval = 0;
             }
             return result;
         }
@@ -53,21 +59,20 @@ namespace Search {
         int score, bestscore = MIN_ALPHA;
         for (BoardMove move: moves) {
             board.makeMove(move);
-            SearchInfo oppAlphaBeta = alphaBeta(board, -1 * beta, -1 * alpha, depthLeft - 1, distanceFromRoot + 1);
+            SearchInfo oppAlphaBeta = alphaBeta(-1 * beta, -1 * alpha, depthLeft - 1, distanceFromRoot + 1);
             board.undoMove(); 
             
-            result.nodes += oppAlphaBeta.nodes;
-            score = -1 * oppAlphaBeta.value;
+            score = -1 * oppAlphaBeta.eval;
             
             // prune if a move is too good; opponent side will avoid playing into this node
             if (score >= beta) {
-                result.value = beta;
+                result.eval = beta;
                 break;
             }
-            // fail-soft stabilizes the search and allows for returned values outside the alpha-beta bounds
+            // fail-soft stabilizes the search and allows for returned.evals outside the alpha-beta bounds
             if (score > bestscore) {
                 result.mateIn = oppAlphaBeta.mateIn;
-                result.value = bestscore = score;
+                result.eval = bestscore = score;
                 result.move = move;
                 if (score > alpha) {
                     alpha = score;

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -76,7 +76,7 @@ namespace Search {
                 result.eval = beta;
                 break;
             }
-            // fail-soft stabilizes the search and allows for returned.evals outside the alpha-beta bounds
+            // fail-soft stabilizes the search and allows for returned values outside the alpha-beta bounds
             if (score > bestscore) {
                 result.eval = bestscore = score;
                 result.move = move;

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -8,13 +8,7 @@
 #include "board.hpp"
 
 namespace Search {
-    Search::Search(Board board) {
-        this->board = board;
-        this->nodes = 0;
-        this->depth = 0;
-    }
-
-    Info Search::search(int depth) {
+    Info Searcher::search(int depth) {
         Info result;
         Node root = this->alphaBeta(MIN_ALPHA, MAX_BETA, depth, 0);
 
@@ -32,7 +26,7 @@ namespace Search {
         return result;
     }
 
-    Node Search::alphaBeta(int alpha, int beta, int depthLeft, int distanceFromRoot) {
+    Node Searcher::alphaBeta(int alpha, int beta, int depthLeft, int distanceFromRoot) {
         Node result;
         this->nodes++;
         this->depth = distanceFromRoot > this->depth ? distanceFromRoot : this->depth;

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -13,9 +13,9 @@ namespace Search {
         this->nodes = 0;
     }
 
-    SearchInfo Search::search(int depth) {
-        SearchInfo result;
-        SearchNode root = this->alphaBeta(MIN_ALPHA, MAX_BETA, depth, 0);
+    Info Search::search(int depth) {
+        Info result;
+        Node root = this->alphaBeta(MIN_ALPHA, MAX_BETA, depth, 0);
 
         result.nodes = this->nodes;
         result.eval = root.eval;
@@ -29,8 +29,8 @@ namespace Search {
         return result;
     }
 
-    SearchNode Search::alphaBeta(int alpha, int beta, int depthLeft, int distanceFromRoot) {
-        SearchNode result;
+    Node Search::alphaBeta(int alpha, int beta, int depthLeft, int distanceFromRoot) {
+        Node result;
         this->nodes++;
 
         // fifty move rule
@@ -68,7 +68,7 @@ namespace Search {
         int score, bestscore = MIN_ALPHA;
         for (BoardMove move: moves) {
             board.makeMove(move);
-            SearchNode oppAlphaBeta = alphaBeta(-1 * beta, -1 * alpha, depthLeft - 1, distanceFromRoot + 1);
+            Node oppAlphaBeta = alphaBeta(-1 * beta, -1 * alpha, depthLeft - 1, distanceFromRoot + 1);
             board.undoMove(); 
             
             score = -1 * oppAlphaBeta.eval;

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -14,13 +14,23 @@ namespace Search {
     }
 
     SearchInfo Search::search(int depth) {
-        SearchInfo result = this->alphaBeta(MIN_ALPHA, MAX_BETA, depth, 0);
+        SearchInfo result;
+        SearchNode root = this->alphaBeta(MIN_ALPHA, MAX_BETA, depth, 0);
+
         result.nodes = this->nodes;
+        result.eval = root.eval;
+        result.move = root.move;
+        if (root.eval > MAX_BETA - 100) {
+            result.mateIn = MAX_BETA - root.eval;
+        }
+        if (root.eval < MIN_ALPHA + 100) {
+            result.mateIn = root.eval - MIN_ALPHA;
+        }
         return result;
     }
 
-    SearchInfo Search::alphaBeta(int alpha, int beta, int depthLeft, int distanceFromRoot) {
-        SearchInfo result;
+    SearchNode Search::alphaBeta(int alpha, int beta, int depthLeft, int distanceFromRoot) {
+        SearchNode result;
         this->nodes++;
 
         // fifty move rule
@@ -47,7 +57,6 @@ namespace Search {
         if (moves.size() == 0) {
             if (currKingInAttack(board)) {
                 result.eval = MIN_ALPHA + distanceFromRoot;
-                result.mateIn = distanceFromRoot;
             }
             else {
                 result.eval = 0;
@@ -59,7 +68,7 @@ namespace Search {
         int score, bestscore = MIN_ALPHA;
         for (BoardMove move: moves) {
             board.makeMove(move);
-            SearchInfo oppAlphaBeta = alphaBeta(-1 * beta, -1 * alpha, depthLeft - 1, distanceFromRoot + 1);
+            SearchNode oppAlphaBeta = alphaBeta(-1 * beta, -1 * alpha, depthLeft - 1, distanceFromRoot + 1);
             board.undoMove(); 
             
             score = -1 * oppAlphaBeta.eval;
@@ -71,7 +80,6 @@ namespace Search {
             }
             // fail-soft stabilizes the search and allows for returned.evals outside the alpha-beta bounds
             if (score > bestscore) {
-                result.mateIn = oppAlphaBeta.mateIn;
                 result.eval = bestscore = score;
                 result.move = move;
                 if (score > alpha) {

--- a/src/search.hpp
+++ b/src/search.hpp
@@ -11,7 +11,7 @@ namespace Search {
     const int NO_MATE = -1;
 
     // used for outside UCI representation    
-    struct SearchInfo {
+    struct Info {
         int nodes;
         int eval;
         int mateIn = NO_MATE;
@@ -19,15 +19,15 @@ namespace Search {
     };
 
     // used for internal searching
-    struct SearchNode {
+    struct Node {
         int eval;
         BoardMove move;
     };
     
     struct Search {
         Search(Board board);
-        SearchInfo search(int depth);
-        SearchNode alphaBeta(int alpha, int beta, int depthLeft, int distanceFromRoot);
+        Info search(int depth);
+        Node alphaBeta(int alpha, int beta, int depthLeft, int distanceFromRoot);
 
         Board board;
         int nodes;

--- a/src/search.hpp
+++ b/src/search.hpp
@@ -13,6 +13,7 @@ namespace Search {
     // used for outside UCI representation    
     struct Info {
         int nodes;
+        int depth;
         int eval;
         int mateIn = NO_MATE;
         BoardMove move;
@@ -31,5 +32,6 @@ namespace Search {
 
         Board board;
         int nodes;
+        int depth;
     };
 } // namespace Search

--- a/src/search.hpp
+++ b/src/search.hpp
@@ -9,18 +9,25 @@ namespace Search {
     const int MIN_ALPHA = -1000000;
     const int MAX_BETA = 1000000;
     const int NO_MATE = -1;
-    
+
+    // used for outside UCI representation    
     struct SearchInfo {
         int nodes;
         int eval;
         int mateIn = NO_MATE;
-        BoardMove move = BoardMove();
+        BoardMove move;
+    };
+
+    // used for internal searching
+    struct SearchNode {
+        int eval;
+        BoardMove move;
     };
     
     struct Search {
         Search(Board board);
         SearchInfo search(int depth);
-        SearchInfo alphaBeta(int alpha, int beta, int depthLeft, int distanceFromRoot);
+        SearchNode alphaBeta(int alpha, int beta, int depthLeft, int distanceFromRoot);
 
         Board board;
         int nodes;

--- a/src/search.hpp
+++ b/src/search.hpp
@@ -25,13 +25,18 @@ namespace Search {
         BoardMove move;
     };
     
-    struct Search {
-        Search(Board board);
-        Info search(int depth);
-        Node alphaBeta(int alpha, int beta, int depthLeft, int distanceFromRoot);
-
-        Board board;
-        int nodes;
-        int depth;
+    class Searcher {
+        public:  
+            Searcher(Board board) {
+                this->board = board;
+                this->nodes = 0;
+                this->depth = 0;
+            }
+            Info search(int depth);
+            Node alphaBeta(int alpha, int beta, int depthLeft, int distanceFromRoot);
+        private:
+            Board board;
+            int nodes;
+            int depth;
     };
 } // namespace Search

--- a/src/search.hpp
+++ b/src/search.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <cstdint>
 #include <utility>
 
 #include "board.hpp"
@@ -12,7 +13,7 @@ namespace Search {
 
     // used for outside UCI representation    
     struct Info {
-        int nodes;
+        uint64_t nodes;
         int depth;
         int eval;
         int mateIn = NO_MATE;
@@ -36,7 +37,7 @@ namespace Search {
             Node alphaBeta(int alpha, int beta, int depthLeft, int distanceFromRoot);
         private:
             Board board;
-            int nodes;
+            uint64_t nodes;
             int depth;
     };
 } // namespace Search

--- a/src/search.hpp
+++ b/src/search.hpp
@@ -12,13 +12,17 @@ namespace Search {
     
     struct SearchInfo {
         int nodes;
-        int value;
+        int eval;
         int mateIn = NO_MATE;
         BoardMove move = BoardMove();
     };
+    
+    struct Search {
+        Search(Board board);
+        SearchInfo search(int depth);
+        SearchInfo alphaBeta(int alpha, int beta, int depthLeft, int distanceFromRoot);
 
-    SearchInfo search(Board& board, int depth);
-    SearchInfo alphaBeta(Board& board, int alpha, int beta, int depthLeft, int distanceFromRoot);
-
+        Board board;
+        int nodes;
+    };
 } // namespace Search
-

--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -118,7 +118,7 @@ namespace Uci {
 
         auto start = std::chrono::high_resolution_clock::now();
         Search::Search currSearch(board);
-        Search::SearchInfo result = currSearch.search(depthToUse);
+        Search::Info result = currSearch.search(depthToUse);
         auto end = std::chrono::high_resolution_clock::now();
         int64_t duration = std::chrono::duration_cast<std::chrono::microseconds>(end - start).count();
         
@@ -126,7 +126,7 @@ namespace Uci {
         std::cout << "bestmove " << result.move.toStr() << "\n";
     }
 
-    void info(Search::SearchInfo searchResult, int64_t searchDuration, int depth) {
+    void info(Search::Info searchResult, int64_t searchDuration, int depth) {
         std::cout << "info depth " << depth << ' ';
         std::cout << "nodes " << searchResult.nodes << ' ';
         if (searchDuration != 0) {

--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -117,7 +117,8 @@ namespace Uci {
         int depthToUse = OPTIONS.depth < TIMEMAN::timeToDepth(allytime) ? OPTIONS.depth : TIMEMAN::timeToDepth(allytime);
 
         auto start = std::chrono::high_resolution_clock::now();
-        Search::SearchInfo result = Search::search(board, depthToUse);
+        Search::Search currSearch(board);
+        Search::SearchInfo result = currSearch.search(depthToUse);
         auto end = std::chrono::high_resolution_clock::now();
         int64_t duration = std::chrono::duration_cast<std::chrono::microseconds>(end - start).count();
         
@@ -135,7 +136,7 @@ namespace Uci {
         }
         
         if (searchResult.mateIn == Search::NO_MATE) {
-            std::cout << "score cp " << (searchResult.value * 100) << ' ';
+            std::cout << "score cp " << (searchResult.eval * 100) << ' ';
         }
         else {
             std::cout << "mate " << searchResult.mateIn / 2 + 1 << ' '; // convert plies to moves

--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -122,12 +122,12 @@ namespace Uci {
         auto end = std::chrono::high_resolution_clock::now();
         int64_t duration = std::chrono::duration_cast<std::chrono::microseconds>(end - start).count();
         
-        info(result, duration, depthToUse);
+        info(result, duration);
         std::cout << "bestmove " << result.move.toStr() << "\n";
     }
 
-    void info(Search::Info searchResult, int64_t searchDuration, int depth) {
-        std::cout << "info depth " << depth << ' ';
+    void info(Search::Info searchResult, int64_t searchDuration) {
+        std::cout << "info depth " << searchResult.depth << ' ';
         std::cout << "nodes " << searchResult.nodes << ' ';
         if (searchDuration != 0) {
             // time is output in milliseconds per the UCI protocol

--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -117,7 +117,7 @@ namespace Uci {
         int depthToUse = OPTIONS.depth < TIMEMAN::timeToDepth(allytime) ? OPTIONS.depth : TIMEMAN::timeToDepth(allytime);
 
         auto start = std::chrono::high_resolution_clock::now();
-        Search::Search currSearch(board);
+        Search::Searcher currSearch(board);
         Search::Info result = currSearch.search(depthToUse);
         auto end = std::chrono::high_resolution_clock::now();
         int64_t duration = std::chrono::duration_cast<std::chrono::microseconds>(end - start).count();

--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -138,8 +138,8 @@ namespace Uci {
         if (searchResult.mateIn == Search::NO_MATE) {
             std::cout << "score cp " << (searchResult.eval * 100) << ' ';
         }
-        else {
-            std::cout << "mate " << searchResult.mateIn / 2 + 1 << ' '; // convert plies to moves
+        else { 
+            std::cout << "mate " << (searchResult.mateIn + 1) / 2 << ' '; // convert plies to moves
         }
         std::cout << '\n';
     }

--- a/src/uci.hpp
+++ b/src/uci.hpp
@@ -19,7 +19,7 @@ namespace Uci {
     void uciLoop();
     Board position(std::istringstream& input);
     void go(std::istringstream& input, Board& board);
-    void info(Search::Info searchResult, int64_t searchDuration, int depth);
+    void info(Search::Info searchResult, int64_t searchDuration);
 
     void isready();
 

--- a/src/uci.hpp
+++ b/src/uci.hpp
@@ -19,7 +19,7 @@ namespace Uci {
     void uciLoop();
     Board position(std::istringstream& input);
     void go(std::istringstream& input, Board& board);
-    void info(Search::SearchInfo searchResult, int64_t searchDuration, int depth);
+    void info(Search::Info searchResult, int64_t searchDuration, int depth);
 
     void isready();
 


### PR DESCRIPTION
In consideration of future efforts to improve search, it should be redefined as a class. Having a shared state for search will generally help make code cleaner while not impacting speed (in fact, speed increases by the tiniest of margins). More parameters will also be able to be defined in search for the future without making the code messier, like it did in the old procedural version.

From startpos with depth 5, main's search currently takes 190,848,362 instructions, while this branch takes 190,839,991.