### PR TITLE
Fast Move Generation For Knights

### DIFF
--- a/src/bitboard.cpp
+++ b/src/bitboard.cpp
@@ -14,6 +14,18 @@ int trailingBit(uint64_t bitboard) {
     return bitboard ? __builtin_clzll(bitboard) : -1;
 }
 
+int popLeadingBit(uint64_t& bitboard) {
+    int pos = leadingBit(bitboard);
+    bitboard ^= 1ull << pos;
+    return pos;
+}
+
+int popTrailingBit(uint64_t& bitboard) {
+    int pos = trailingBit(bitboard);
+    bitboard ^= 1ull << pos;
+    return pos;
+}
+
 uint64_t flipVertical(uint64_t bitboard) {
     uint64_t k1 = 0x00FF00FF00FF00FFull;
     uint64_t k2 = 0x0000FFFF0000FFFFull;
@@ -123,19 +135,17 @@ bool straightAttackers(int square, uint64_t allPieces, uint64_t enemies) {
     return closestStraights & enemies;
 }
 
-bool knightAttackers(int square, uint64_t enemyKnights) {
-    uint64_t currPiece = 1ull << square;
-    // prevent currPiece from teleporting to other side of the board with bit shifts
-    uint64_t left1 = (currPiece >> 1) & NOT_FILE_H;
-    uint64_t left2 = (currPiece >> 2) & NOT_FILE_HG;
-    uint64_t right1 = (currPiece << 1) & NOT_FILE_A;
-    uint64_t right2 = (currPiece << 2) & NOT_FILE_AB;
+uint64_t knightSquares(uint64_t knights) {
+    uint64_t left1 = (knights >> 1) & NOT_FILE_H;
+    uint64_t left2 = (knights >> 2) & NOT_FILE_HG;
+    uint64_t right1 = (knights << 1) & NOT_FILE_A;
+    uint64_t right2 = (knights << 2) & NOT_FILE_AB;
 
     uint64_t height1 = left1 | right1;
     uint64_t height2 = left2 | right2;
     
     uint64_t knightSquares = (height1 << 16) | (height1 >> 16) | (height2 << 8) | (height2 >> 8);
-    return knightSquares & enemyKnights;
+    return knightSquares;
 }
 
 bool pawnAttackers(int square, uint64_t enemyPawns, bool isWhiteTurn) {

--- a/src/bitboard.hpp
+++ b/src/bitboard.hpp
@@ -54,6 +54,9 @@ const static std::array<uint64_t, 15> DIAGS_MASK = {DIAG_0, DIAG_1, DIAG_2, DIAG
 
 int leadingBit(uint64_t bitboard);
 int trailingBit(uint64_t bitboard);
+int popLeadingBit(uint64_t& bitboard);
+int popTrailingBit(uint64_t& bitboard);
+
 uint64_t flipVertical(uint64_t bitboard);
 
 int getFile(int square);
@@ -66,7 +69,7 @@ uint64_t getAntiDiagMask(int square);
 
 bool diagAttackers(int square, uint64_t allPieces, uint64_t enemies);
 bool straightAttackers(int square, uint64_t allPieces, uint64_t enemies);
-bool knightAttackers(int square, uint64_t enemyKnights);
+uint64_t knightSquares(uint64_t knights);
 bool pawnAttackers(int square, uint64_t enemyPawns, bool isWhiteTurn);
 bool kingAttackers(int square, uint64_t enemyKings);
 

--- a/src/board.cpp
+++ b/src/board.cpp
@@ -474,7 +474,7 @@ bool currKingInAttack(Board& board) {
 
     return diagAttackers(kingSquare, allPieces, enemyQueens | enemyBishops)
         || straightAttackers(kingSquare, allPieces, enemyQueens | enemyRooks)
-        || knightAttackers(kingSquare, enemyKnights)
+        || knightSquares(enemyKnights) & 1ull << kingSquare
         || pawnAttackers(kingSquare, enemyPawns, board.isWhiteTurn)
         || kingAttackers(kingSquare, enemyKings);
 }

--- a/src/move.cpp
+++ b/src/move.cpp
@@ -15,6 +15,11 @@ BoardSquare::BoardSquare(std::string input) {
     this->rank = 8 - int(input.at(1) - '1') - 1;
 }
 
+BoardSquare::BoardSquare(int square) {
+    this->rank = square / 8;
+    this->file = fileVals(square % 8);
+}
+
 int BoardSquare::toSquare() {
     return this->rank * 8 + this->file;
 }

--- a/src/move.hpp
+++ b/src/move.hpp
@@ -9,6 +9,7 @@ struct BoardSquare {
     BoardSquare(int a_rank, fileVals a_file): rank(a_rank), file(a_file) {};
     BoardSquare(int a_rank, int a_file): rank(a_rank), file(fileVals(a_file)) {};
     BoardSquare(std::string input);
+    BoardSquare(int square); // from square
     std::string toStr();
     int toSquare();
     bool isValid() const;

--- a/src/moveGen.cpp
+++ b/src/moveGen.cpp
@@ -104,26 +104,13 @@ namespace MOVEGEN {
     }
 
     void validKnightMoves(Board& currBoard, std::vector<BoardMove>& validMoves, std::vector<BoardSquare>& knights) {
-        for (BoardSquare knight: knights) {
-            int currRank = knight.rank;
-            fileVals currFile = knight.file;
-            std::vector<BoardSquare> knightMoves;
-            std::vector<BoardSquare> potentialMoves = {
-                BoardSquare(currRank - 2, currFile - 1),
-                BoardSquare(currRank - 2, currFile + 1),
-                BoardSquare(currRank + 2, currFile - 1),
-                BoardSquare(currRank + 2, currFile + 1),
-                BoardSquare(currRank - 1, currFile - 2),
-                BoardSquare(currRank - 1, currFile + 2),
-                BoardSquare(currRank + 1, currFile - 2),
-                BoardSquare(currRank + 1, currFile + 2),
-            };
-            for (BoardSquare square: potentialMoves) {
-                if (square.isValid() && !isFriendlyPiece(currBoard, square)) {
-                    knightMoves.push_back(square);
-                }
-            }
-            for (BoardSquare move: knightMoves) {
+        uint64_t allies = currBoard.isWhiteTurn ? currBoard.pieceSets[WHITE_PIECES] : currBoard.pieceSets[BLACK_PIECES];
+        for (BoardSquare knight: knights) { 
+            uint64_t knightBitboard = 1ull << knight.toSquare();
+            uint64_t knightMoves = knightSquares(knightBitboard) & ~allies;
+            while (knightMoves) {
+                int currSquare = popLeadingBit(knightMoves);
+                BoardSquare move(currSquare);
                 currBoard.makeMove(knight, move);
                 if (!currBoard.isIllegalPos) {
                     validMoves.push_back(BoardMove(knight, move));

--- a/src/moveGen.cpp
+++ b/src/moveGen.cpp
@@ -1,7 +1,9 @@
 #include "moveGen.hpp"
 
+#include <cstdint>
 #include <vector>
 #include <stdexcept>
+#include <iostream>
 
 namespace MOVEGEN {
 
@@ -279,11 +281,11 @@ namespace MOVEGEN {
     // perft is a method of determining correctness of move generators
     // positions can be input and number of total leaf nodes determined
     // the number determined can be compared to a table to established values from others
-    int perft(Board board, int depthLeft) {
+    uint64_t perft(Board board, int depthLeft) {
         if (depthLeft == 0) {
             return 1;
         }
-        int leafNodeCount = 0;
+        uint64_t leafNodeCount = 0;
         std::vector<BoardMove> moves = moveGenerator(board);
         for (auto move: moves) {
             board.makeMove(move);

--- a/src/moveGen.hpp
+++ b/src/moveGen.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <cstdint>
 #include <vector>
 
 #include "board.hpp"
@@ -22,5 +23,5 @@ namespace MOVEGEN {
     void pawnCaptures(Board& currBoard, std::vector<BoardSquare>& pawnMoves, BoardSquare pawn, int fileDirection);
 
     // for debugging 
-    int perft(Board currBoard, int depthLeft);
+    uint64_t perft(Board currBoard, int depthLeft);
 } // namespace MOVEGEN

--- a/src/timeman.cpp
+++ b/src/timeman.cpp
@@ -4,6 +4,7 @@ namespace TIMEMAN {
     int timeToDepth(int ms) {
         // these values are completely arbitrary and only serve to be used to found development
         // for time management later on and prevent time outs for increasing depths
+        if (ms >= 10000000) {return 10;}
         if (ms >= 1000000) {return 7;}
         if (ms >= 500000) {return 6;}
         if (ms >= 30000) {return 5;}

--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -7,6 +7,7 @@
 #include "uci.hpp"
 #include "timeman.hpp"
 #include "search.hpp"
+#include "moveGen.hpp"
 #include "board.hpp"
 
 namespace Uci {
@@ -66,6 +67,7 @@ namespace Uci {
             else if (commandToken == "position") {currBoard = position(commandStream);}
             else if (commandToken == "go") {Uci::go(commandStream, currBoard);}
             else if (commandToken == "isready") {isready();}
+            else if (commandToken == "perft") {perft(currBoard);}
             else if (commandToken == "quit") {return;}
         }
     }
@@ -148,5 +150,15 @@ namespace Uci {
         std::cout << "readyok\n";
     }
 
+    void perft(Board& board) {
+        auto start = std::chrono::high_resolution_clock::now();
+        uint64_t nodes = MOVEGEN::perft(board, OPTIONS.depth);
+        auto end = std::chrono::high_resolution_clock::now();
+        int64_t duration = std::chrono::duration_cast<std::chrono::microseconds>(end - start).count();
+        std::cout << "perft result nodes " << nodes;
+        std::cout << " nps " << nodes * 1000000 / duration;
+        std::cout << " time " << duration / 1000 << "\n";
+
+    }
 } // namespace Uci
 

--- a/src/uci.hpp
+++ b/src/uci.hpp
@@ -23,4 +23,7 @@ namespace Uci {
 
     void isready();
 
+    // for debugging
+    void perft(Board& board);
+
 } // namespace Uci

--- a/tests/testBitBoard.cpp
+++ b/tests/testBitBoard.cpp
@@ -470,10 +470,11 @@ TEST(BitboardTest, knightAttackersTrue1) {
 
     int rank = 4, file = 3;
     int square = rank * 8 + file;
+    uint64_t king = 1ull << square;
 
     uint64_t enemies = arrayToBitboard(enemiesBoard);
-
-    EXPECT_EQ(knightAttackers(square, enemies), true);
+    bool attacked = knightSquares(enemies) & king;
+    EXPECT_EQ(attacked, true);
 }
 
 TEST(BitboardTest, knightAttackersTrue2) {
@@ -490,10 +491,10 @@ TEST(BitboardTest, knightAttackersTrue2) {
 
     int rank = 4, file = 3;
     int square = rank * 8 + file;
-
+    uint64_t king = 1ull << square;
     uint64_t enemies = arrayToBitboard(enemiesBoard);
-
-    EXPECT_EQ(knightAttackers(square, enemies), true);
+    bool attacked = knightSquares(enemies) & king;
+    EXPECT_EQ(attacked, true);
 }
 
 TEST(BitboardTest, knightAttackersTrue3) {
@@ -510,10 +511,10 @@ TEST(BitboardTest, knightAttackersTrue3) {
 
     int rank = 4, file = 3;
     int square = rank * 8 + file;
-
+    uint64_t king = 1ull << square;   
     uint64_t enemies = arrayToBitboard(enemiesBoard);
-
-    EXPECT_EQ(knightAttackers(square, enemies), true);
+    bool attacked = knightSquares(enemies) & king;
+    EXPECT_EQ(attacked, true);
 }
 
 TEST(BitboardTest, knightAttackersTrue4) {
@@ -530,10 +531,10 @@ TEST(BitboardTest, knightAttackersTrue4) {
 
     int rank = 7, file = 0;
     int square = rank * 8 + file;
-
+    uint64_t king = 1ull << square;
     uint64_t enemies = arrayToBitboard(enemiesBoard);
-
-    EXPECT_EQ(knightAttackers(square, enemies), true);
+    bool attacked = knightSquares(enemies) & king;
+    EXPECT_EQ(attacked, true);
 }
 
 TEST(BitboardTest, knightAttackersFalse) {
@@ -550,10 +551,10 @@ TEST(BitboardTest, knightAttackersFalse) {
 
     int rank = 7, file = 0;
     int square = rank * 8 + file;
-
+    uint64_t king = 1ull << square;
     uint64_t enemies = arrayToBitboard(enemiesBoard);
-
-    EXPECT_EQ(knightAttackers(square, enemies), false);
+    bool attacked = knightSquares(enemies) & king;
+    EXPECT_EQ(attacked, false);
 }
 
 TEST(BitboardTest, pawnAttackersTrue1) {

--- a/tests/testBitBoard.cpp
+++ b/tests/testBitBoard.cpp
@@ -456,11 +456,11 @@ TEST(BitboardTest, straightAttackersTrue2) {
     EXPECT_EQ(straightAttackers(square, allies | enemies, enemies), true);
 }
 
-TEST(BitboardTest, knightAttackersTrue1) {
+TEST(BitboardTest, knightSquares1) {
     std::array<pieceTypes, BOARD_SIZE> enemiesBoard = {
+        WKnight   , EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece,
         EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece,
         EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece,
-        EmptyPiece, EmptyPiece, WKnight   , EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece,
         EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece,
         EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece,
         EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece,
@@ -468,16 +468,12 @@ TEST(BitboardTest, knightAttackersTrue1) {
         EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece,
     };
 
-    int rank = 4, file = 3;
-    int square = rank * 8 + file;
-    uint64_t king = 1ull << square;
-
     uint64_t enemies = arrayToBitboard(enemiesBoard);
-    bool attacked = knightSquares(enemies) & king;
-    EXPECT_EQ(attacked, true);
+    uint64_t knightBitboard = knightSquares(enemies);
+    EXPECT_EQ(knightBitboard, 0x0000000000020400ull);
 }
 
-TEST(BitboardTest, knightAttackersTrue2) {
+TEST(BitboardTest, knightSquares2) {
     std::array<pieceTypes, BOARD_SIZE> enemiesBoard = {
         EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece,
         EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece,
@@ -489,15 +485,12 @@ TEST(BitboardTest, knightAttackersTrue2) {
         EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece,
     };
 
-    int rank = 4, file = 3;
-    int square = rank * 8 + file;
-    uint64_t king = 1ull << square;
     uint64_t enemies = arrayToBitboard(enemiesBoard);
-    bool attacked = knightSquares(enemies) & king;
-    EXPECT_EQ(attacked, true);
+    uint64_t knightBitboard = knightSquares(enemies);
+    EXPECT_EQ(knightBitboard, 0x0000050800080500ull);
 }
 
-TEST(BitboardTest, knightAttackersTrue3) {
+TEST(BitboardTest, knightSquares3) {
     std::array<pieceTypes, BOARD_SIZE> enemiesBoard = {
         EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece,
         EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece,
@@ -509,15 +502,12 @@ TEST(BitboardTest, knightAttackersTrue3) {
         EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece,
     };
 
-    int rank = 4, file = 3;
-    int square = rank * 8 + file;
-    uint64_t king = 1ull << square;   
     uint64_t enemies = arrayToBitboard(enemiesBoard);
-    bool attacked = knightSquares(enemies) & king;
-    EXPECT_EQ(attacked, true);
+    uint64_t knightBitboard = knightSquares(enemies);
+    EXPECT_EQ(knightBitboard, 0x0508000805000000ull);
 }
 
-TEST(BitboardTest, knightAttackersTrue4) {
+TEST(BitboardTest, knightSquares4) {
     std::array<pieceTypes, BOARD_SIZE> enemiesBoard = {
         EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece,
         EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece,
@@ -529,15 +519,12 @@ TEST(BitboardTest, knightAttackersTrue4) {
         EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece,
     };
 
-    int rank = 7, file = 0;
-    int square = rank * 8 + file;
-    uint64_t king = 1ull << square;
     uint64_t enemies = arrayToBitboard(enemiesBoard);
-    bool attacked = knightSquares(enemies) & king;
-    EXPECT_EQ(attacked, true);
+    uint64_t knightBitboard = knightSquares(enemies);
+    EXPECT_EQ(knightBitboard, 0x1100110A00000000ull);
 }
 
-TEST(BitboardTest, knightAttackersFalse) {
+TEST(BitboardTest, knightSquares5) {
     std::array<pieceTypes, BOARD_SIZE> enemiesBoard = {
         EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece,
         EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece,
@@ -549,12 +536,9 @@ TEST(BitboardTest, knightAttackersFalse) {
         EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, WKnight   , EmptyPiece, EmptyPiece, EmptyPiece,
     };
 
-    int rank = 7, file = 0;
-    int square = rank * 8 + file;
-    uint64_t king = 1ull << square;
     uint64_t enemies = arrayToBitboard(enemiesBoard);
-    bool attacked = knightSquares(enemies) & king;
-    EXPECT_EQ(attacked, false);
+    uint64_t knightBitboard = knightSquares(enemies);
+    EXPECT_EQ(knightBitboard, 0x22442A1400000000ull);
 }
 
 TEST(BitboardTest, pawnAttackersTrue1) {


### PR DESCRIPTION
Thinking about migrating move generation to bitboard generation, starting with the knights here. The main issue is checking for correctness of generation. Alpha beta search trees are not the same since the new proposed bitboard method produces moves in a different order, which causes pruning to function differently. 

![image](https://github.com/knguy22/Blocky-Chess-Engine/assets/77951761/6f05cca5-a9e6-4024-b966-e1d15899cd7e)

Here are some depth 4 games. Interestingly, the new version is better at white and worse at black, which makes sense since the bitboard generation generates knight moves towards rank 8 first, which is good for white but bad for black. 

In order to make sure for correctness, perft tests will be expanded and tested for. 