### PR TITLE
Move ordering + increase default depth to 6

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,6 +25,7 @@ target_sources(Blocky PRIVATE
     src/move.cpp
     src/board.cpp
     src/moveGen.cpp
+    src/movePicker.cpp
     src/search.cpp
     src/eval.cpp
     src/timeman.cpp

--- a/src/movePicker.cpp
+++ b/src/movePicker.cpp
@@ -17,7 +17,8 @@ MovePicker::MovePicker(std::vector<BoardMove>&& a_moves) {
 void MovePicker::assignMoveScores(const Board& board) {
     size_t i = 0;
     for (BoardMove move: this->moves) {
-        // capture 
+        // capture
+        // moveGen outputs least valuable piece moves first, so least value captures is automatic 
         if (board.getPiece(move.pos2) != EmptyPiece) {
             this->moveScores[i] = 1;
         }

--- a/src/movePicker.cpp
+++ b/src/movePicker.cpp
@@ -1,0 +1,49 @@
+#include <vector>
+
+#include "movePicker.hpp"
+#include "board.hpp"
+#include "move.hpp"
+#include "types.hpp"
+
+MovePicker::MovePicker(std::vector<BoardMove>&& a_moves) {
+    this->moves = a_moves;
+    this->moveScores = std::vector<int>(moves.size());
+    this->size = moves.size();
+    this->movesPicked = 0;
+};
+
+// move score assignment is implemented that more promising moves are given higher scores
+// regular moves have a score of 0
+void MovePicker::assignMoveScores(const Board& board) {
+    size_t i = 0;
+    for (BoardMove move: this->moves) {
+        // capture 
+        if (board.getPiece(move.pos2) != EmptyPiece) {
+            this->moveScores[i] = 1;
+        }
+        // default
+        else {
+            this->moveScores[i] = 0;
+        }
+        i++;
+    }
+}
+
+bool MovePicker::movesLeft() const {
+    return this->movesPicked < this->size;
+}
+
+// insertion sort is used to track picked moves because it is faster for very small sorted arrays
+// small sorted arrays can be expected with more pruning from search
+BoardMove MovePicker::pickMove() {
+    auto begin = this->moveScores.begin() + this->movesPicked;
+    auto end = this->moveScores.end();
+    size_t maxIndex = std::distance(this->moveScores.begin(), std::max_element(begin, end));
+    
+    std::swap(this->moveScores[maxIndex], this->moveScores[movesPicked]);
+    std::swap(this->moves[maxIndex], this->moves[movesPicked]);
+    BoardMove move = this->moves[movesPicked];
+    
+    this->movesPicked++;
+    return move;
+}

--- a/src/movePicker.hpp
+++ b/src/movePicker.hpp
@@ -1,0 +1,21 @@
+#pragma once
+
+#include <vector>
+
+#include "board.hpp"
+#include "move.hpp"
+#include "types.hpp"
+
+class MovePicker {
+    public:
+        MovePicker(std::vector<BoardMove>&& a_moves); 
+        void assignMoveScores(const Board& board);
+        bool movesLeft() const;
+        BoardMove pickMove();
+    
+    private:
+        std::vector<BoardMove> moves;
+        std::vector<int> moveScores;
+        int movesPicked;
+        int size;
+};

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -3,6 +3,7 @@
 #include <iostream>
 
 #include "search.hpp"
+#include "movePicker.hpp"
 #include "eval.hpp"
 #include "moveGen.hpp"
 #include "board.hpp"
@@ -13,7 +14,7 @@ namespace Search {
         Node root = this->alphaBeta(MIN_ALPHA, MAX_BETA, depth, 0);
 
         result.nodes = this->nodes;
-        result.depth = this->depth;
+        result.depth = this->max_depth;
         
         result.eval = root.eval;
         result.move = root.move;
@@ -29,7 +30,7 @@ namespace Search {
     Node Searcher::alphaBeta(int alpha, int beta, int depthLeft, int distanceFromRoot) {
         Node result;
         this->nodes++;
-        this->depth = distanceFromRoot > this->depth ? distanceFromRoot : this->depth;
+        this->max_depth = distanceFromRoot > this->max_depth ? distanceFromRoot : this->max_depth;
 
         // fifty move rule
         if (this->board.fiftyMoveRule == 100) {
@@ -62,9 +63,14 @@ namespace Search {
             return result;
         }
 
+        // init movePicker
+        MovePicker movePicker(std::move(moves));
+        movePicker.assignMoveScores(board);
+
         // start search through moves
         int score, bestscore = MIN_ALPHA;
-        for (BoardMove move: moves) {
+        while (movePicker.movesLeft()) {
+            BoardMove move = movePicker.pickMove();
             board.makeMove(move);
             Node oppAlphaBeta = alphaBeta(-1 * beta, -1 * alpha, depthLeft - 1, distanceFromRoot + 1);
             board.undoMove(); 

--- a/src/search.hpp
+++ b/src/search.hpp
@@ -31,13 +31,13 @@ namespace Search {
             Searcher(Board a_board) {
                 this->board = a_board;
                 this->nodes = 0;
-                this->depth = 0;
+                this->max_depth = 0;
             }
             Info search(int depth);
             Node alphaBeta(int alpha, int beta, int depthLeft, int distanceFromRoot);
         private:
             Board board;
             uint64_t nodes;
-            int depth;
+            int max_depth;
     };
 } // namespace Search

--- a/src/timeman.cpp
+++ b/src/timeman.cpp
@@ -5,12 +5,13 @@ namespace TIMEMAN {
         // these values are completely arbitrary and only serve to be used to found development
         // for time management later on and prevent time outs for increasing depths
         if (ms >= 10000000) {return 10;}
-        if (ms >= 1000000) {return 7;}
-        if (ms >= 500000) {return 6;}
-        if (ms >= 30000) {return 5;}
-        if (ms >= 2000) {return 4;}
-        if (ms >= 500) {return 3;}
-        if (ms >= 100) {return 2;}
+        if (ms >= 1000000) {return 8;}
+        if (ms >= 500000) {return 7;}
+        if (ms >= 30000) {return 6;}
+        if (ms >= 2000) {return 5;}
+        if (ms >= 500) {return 4;}
+        if (ms >= 100) {return 3;}
+        if (ms >= 20) {return 2;}
         return 1;
     }
 } // namespace TIMEMAN

--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -23,7 +23,7 @@ namespace Uci {
         std::cout << "id name BLOCKY\n";
         std::cout << "id author BlockyTeam\n";
 
-        std::cout << "option name Depth type spin default 5 min 1 max 7\n";
+        std::cout << "option name Depth type spin default 6 min 1 max 7\n";
 
         std::cout << "uciok\n";
         return true;

--- a/src/uci.hpp
+++ b/src/uci.hpp
@@ -8,7 +8,7 @@
 
 namespace Uci {
     struct UciOptions {
-        int depth = 5;
+        int depth = 6;
     };
 
     bool uci();

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -29,6 +29,7 @@ add_executable(
     ../src/move.cpp
     ../src/board.cpp
     ../src/moveGen.cpp
+    ../src/movePicker.cpp
     ../src/search.cpp
     ../src/eval.cpp
 )


### PR DESCRIPTION
Move ordering is a technique that involves pruning more by searching expected best moves first. This is a naive implementation that will likely make it much more feasible to reach higher depths as Blocky continues to improve. 

Nodes per second will obviously go down due to move ranking, but the expected pruning gains will by far make up for it. Of course, elo testing will have to be done besides these benchmarks.

For example, a search from startpos with depth 7:

![image](https://github.com/knguy22/Blocky-Chess-Engine/assets/77951761/51c50965-d4cf-4987-87bc-faf693c2c256)

Instructions read with depth 6:

![image](https://github.com/knguy22/Blocky-Chess-Engine/assets/77951761/7c01969b-1a9e-40df-b88d-efe48350e7d1)
