### PR TITLE
Add isLegalMove function to movegen

### DIFF
--- a/src/board.cpp
+++ b/src/board.cpp
@@ -28,7 +28,6 @@ Board::Board() {
     this->isWhiteTurn = true;
     this->fiftyMoveRule = 0;
     this->pawnJumpedSquare = BoardSquare();
-    this->isIllegalPos = false;
     this->castlingRights = All_Castle;
     this->materialDifference = 0;
     this->eval = EvalAttributes();
@@ -62,12 +61,11 @@ Board::Board() {
 // Used for debugging and testing
 Board::Board(std::array<pieceTypes, BOARD_SIZE> a_board, bool a_isWhiteTurn, 
             int a_fiftyMoveRule, BoardSquare a_pawnJumpedSquare, 
-            bool a_isIllegalPos, castleRights a_castlingRights, int a_materialDifference) {
+            castleRights a_castlingRights, int a_materialDifference) {
     this->board = a_board;
     this->isWhiteTurn = a_isWhiteTurn;
     this->fiftyMoveRule = a_fiftyMoveRule;
     this->pawnJumpedSquare = a_pawnJumpedSquare;
-    this->isIllegalPos = a_isIllegalPos;
     this->castlingRights = a_castlingRights;
     this->materialDifference = a_materialDifference;
 
@@ -154,8 +152,6 @@ Board::Board(std::string fenStr) {
 
     fenStream >> token;
     this->fiftyMoveRule = stoi(token);
-
-    this->isIllegalPos = false; // it is up to the UCI gui to not give illegal positions
 
     this->initZobristKey();
     // Board doesn't use Fullmove counter
@@ -373,9 +369,6 @@ void Board::makeMove(BoardSquare pos1, BoardSquare pos2, pieceTypes promotionPie
         this->zobristKey ^= Zobrist::enPassKeys[oldPawnJumpedSquare.file];
     }	
     
-    // check for illegality 
-    this->isIllegalPos = currKingInAttack(*this);
-
     // after finalizing move logic, now switch turns
     this->isWhiteTurn = !this->isWhiteTurn; 
     this->zobristKey ^= Zobrist::isBlackKey;
@@ -421,12 +414,41 @@ void Board::undoMove() {
     this->pawnJumpedSquare = prev.pawnJumpedSquare;
     this->fiftyMoveRule = prev.fiftyMoveRule;
     this->materialDifference = prev.materialDifference;
-    this->isIllegalPos = false;
     this->eval = prev.eval;
 
     this->moveHistory.pop_back();
     this->zobristKeyHistory.pop_back();
     this->zobristKey = zobristKeyHistory.back();
+}
+
+bool Board::isLegalMove(const BoardMove move) const {
+    // This is a bitboard implementation to check whether a move leaves the ally king under attack
+    // The current move generation already checks whether castling is even valid 
+    // or squares unblocked so only the king final position needs to be checked
+
+    assert(move.isValid());
+
+    std::array<uint64_t, NUM_BITBOARDS> tmpPieceSets = this->pieceSets;
+    pieceTypes originColor = this->isWhiteTurn ? WHITE_PIECES : BLACK_PIECES;
+
+    uint64_t originSquare = (1ull << move.pos1.toSquare());
+    uint64_t targetSquare = (1ull << move.pos2.toSquare());
+    pieceTypes originPiece = this->getPiece(move.pos1);
+    pieceTypes targetPiece = this->getPiece(move.pos2);
+
+    // move ally piece 
+    tmpPieceSets[originColor] ^= originSquare;
+    tmpPieceSets[originPiece] ^= originSquare;
+    tmpPieceSets[originColor] ^= targetSquare;
+    tmpPieceSets[originPiece] ^= targetSquare;
+
+    if (targetPiece != EmptyPiece) {
+        pieceTypes targetColor = this->isWhiteTurn ? BLACK_PIECES : WHITE_PIECES;
+        tmpPieceSets[targetColor] ^= targetSquare;
+        tmpPieceSets[targetPiece] ^= targetSquare;
+    }
+    
+    return !currKingInAttack(tmpPieceSets, this->isWhiteTurn);
 }
 
 // getPiece is not responsible for bounds checking
@@ -503,7 +525,6 @@ std::ostream& operator<<(std::ostream& os, const Board& target) {
     }
     os << "\n";
     os << "castlingRights: " << target.castlingRights << "\n";
-    os << "isIllegalPos: " << target.isIllegalPos << "\n";
     os << "isWhiteTurn: " << target.isWhiteTurn << "\n";
     os << "50MoveRule: " << target.fiftyMoveRule << "\n";
     os << "ZobristKey: " << target.zobristKey << "\n";
@@ -528,24 +549,24 @@ castleRights castleRightsBit(BoardSquare finalKingPos, bool isWhiteTurn) {
     }
 }
 
-bool currKingInAttack(Board& board) {
-    pieceTypes allyKing = board.isWhiteTurn ? WKing : BKing;
-    int kingSquare = leadingBit(board.pieceSets[allyKing]);
+bool currKingInAttack(std::array<uint64_t, NUM_BITBOARDS>& pieceSets, bool isWhiteTurn) {
+    pieceTypes allyKing = isWhiteTurn ? WKing : BKing;
+    int kingSquare = leadingBit(pieceSets[allyKing]);
     assert(kingSquare != -1);
 
-    uint64_t allPieces = board.pieceSets[WHITE_PIECES] | board.pieceSets[BLACK_PIECES];
+    uint64_t allPieces = pieceSets[WHITE_PIECES] | pieceSets[BLACK_PIECES];
 
-    uint64_t enemyKings   = board.isWhiteTurn ? board.pieceSets[BKing]   : board.pieceSets[WKing];
-    uint64_t enemyQueens  = board.isWhiteTurn ? board.pieceSets[BQueen]  : board.pieceSets[WQueen];
-    uint64_t enemyBishops = board.isWhiteTurn ? board.pieceSets[BBishop] : board.pieceSets[WBishop];
-    uint64_t enemyRooks   = board.isWhiteTurn ? board.pieceSets[BRook]   : board.pieceSets[WRook];
-    uint64_t enemyKnights = board.isWhiteTurn ? board.pieceSets[BKnight] : board.pieceSets[WKnight];
-    uint64_t enemyPawns   = board.isWhiteTurn ? board.pieceSets[BPawn]   : board.pieceSets[WPawn];
+    uint64_t enemyKings   = isWhiteTurn ? pieceSets[BKing]   : pieceSets[WKing];
+    uint64_t enemyQueens  = isWhiteTurn ? pieceSets[BQueen]  : pieceSets[WQueen];
+    uint64_t enemyBishops = isWhiteTurn ? pieceSets[BBishop] : pieceSets[WBishop];
+    uint64_t enemyRooks   = isWhiteTurn ? pieceSets[BRook]   : pieceSets[WRook];
+    uint64_t enemyKnights = isWhiteTurn ? pieceSets[BKnight] : pieceSets[WKnight];
+    uint64_t enemyPawns   = isWhiteTurn ? pieceSets[BPawn]   : pieceSets[WPawn];
 
     return Attacks::bishopAttacks(kingSquare, allPieces) & (enemyBishops | enemyQueens)
         || Attacks::rookAttacks(kingSquare, allPieces) & (enemyRooks | enemyQueens)
         || knightSquares(enemyKnights) & 1ull << kingSquare
-        || pawnAttackers(kingSquare, enemyPawns, board.isWhiteTurn)
+        || pawnAttackers(kingSquare, enemyPawns, isWhiteTurn)
         || kingAttackers(kingSquare, enemyKings);
 }
 

--- a/src/board.hpp
+++ b/src/board.hpp
@@ -41,7 +41,7 @@ struct Board {
     Board();
     Board(std::array<pieceTypes, BOARD_SIZE> a_board, bool a_isWhiteTurn = true, 
             int a_fiftyMoveRule = 0, BoardSquare a_pawnJumpedSquare = BoardSquare(), 
-            bool a_isIllegalPos = false, castleRights a_castlingRights = All_Castle, int a_materialDifference = 0); 
+            castleRights a_castlingRights = All_Castle, int a_materialDifference = 0); 
     // for production
     Board(std::string fenStr);
     std::string toFen();
@@ -50,6 +50,7 @@ struct Board {
     void makeMove(BoardSquare pos1, BoardSquare pos2, pieceTypes promotionPiece = nullPiece);
     void makeMove(BoardMove move);
     void undoMove();
+    bool isLegalMove(const BoardMove move) const;
     bool moveIsCapture(BoardMove move);
     
     friend bool operator==(const Board& lhs, const Board& rhs);
@@ -69,7 +70,6 @@ struct Board {
     bool isWhiteTurn;
     castleRights castlingRights; // bitwise castling rights tracker
     int fiftyMoveRule;
-    bool isIllegalPos;
     BoardSquare pawnJumpedSquare; // en passant square
     int materialDifference; // updates on capture or promotion, so the eval doesn't have to calculate for each board, positive is white advantage
                             // Possibly could be combined with attributes
@@ -80,7 +80,7 @@ struct Board {
 };
 
 castleRights castleRightsBit(BoardSquare finalKingPos, bool isWhiteTurn);
-bool currKingInAttack(Board& board);
+bool currKingInAttack(std::array<uint64_t, NUM_BITBOARDS>& pieceSets, bool isWhiteTurn);
 
 // for debugging
 uint64_t makeBitboardFromArray(std::array<pieceTypes, BOARD_SIZE> board, int target);

--- a/src/move.cpp
+++ b/src/move.cpp
@@ -1,5 +1,6 @@
 #include <string>
 #include <sstream>
+#include <iostream>
 #include <array>
 
 #include "move.hpp"
@@ -20,7 +21,7 @@ BoardSquare::BoardSquare(int square) {
     this->file = fileVals(square % 8);
 }
 
-int BoardSquare::toSquare() {
+int BoardSquare::toSquare() const {
     return this->rank * 8 + this->file;
 }
 

--- a/src/move.hpp
+++ b/src/move.hpp
@@ -11,7 +11,7 @@ struct BoardSquare {
     BoardSquare(std::string input);
     BoardSquare(int square); // from square
     std::string toStr();
-    int toSquare();
+    int toSquare() const;
     bool isValid() const;
 
     friend bool operator==(const BoardSquare& lhs, const BoardSquare& rhs);

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -54,7 +54,7 @@ namespace Search {
         // checkmate or stalemate
         std::vector<BoardMove> moves = MOVEGEN::moveGenerator(this->board);
         if (moves.size() == 0) {
-            if (currKingInAttack(board)) {
+            if (currKingInAttack(board.pieceSets, board.isWhiteTurn)) {
                 result.eval = MIN_ALPHA + distanceFromRoot;
             }
             else {

--- a/tests/testBoard.cpp
+++ b/tests/testBoard.cpp
@@ -71,7 +71,6 @@ TEST_F(BoardTest, fenConstructorDefault) {
     EXPECT_EQ(fenBoard.board, defaultBoard.board);
     EXPECT_EQ(fenBoard.zobristKey, defaultBoard.zobristKey);
     EXPECT_NE(fenBoard.zobristKey, 0);
-    EXPECT_EQ(fenBoard.zobristKeyHistory.back(), fenBoard.zobristKey);
     EXPECT_EQ(fenBoard.isWhiteTurn, defaultBoard.isWhiteTurn);
     EXPECT_EQ(fenBoard.castlingRights, defaultBoard.castlingRights);
     EXPECT_EQ(fenBoard.pawnJumpedSquare, defaultBoard.pawnJumpedSquare);
@@ -87,7 +86,6 @@ TEST_F(BoardTest, fenConstructorEnPassantSquare) {
     EXPECT_EQ(fenBoard.board, moveBoard.board);
     EXPECT_EQ(fenBoard.zobristKey, moveBoard.zobristKey);
     EXPECT_NE(fenBoard.zobristKey, 0);
-    EXPECT_EQ(fenBoard.zobristKeyHistory.back(), fenBoard.zobristKey);
     EXPECT_EQ(fenBoard.isWhiteTurn, moveBoard.isWhiteTurn);
     EXPECT_EQ(fenBoard.castlingRights, moveBoard.castlingRights);
     EXPECT_EQ(fenBoard.pawnJumpedSquare, moveBoard.pawnJumpedSquare);
@@ -110,7 +108,6 @@ TEST_F(BoardTest, fenConstructorEnPassantCastle) {
     EXPECT_EQ(fenBoard.board, moveBoard.board);
     EXPECT_EQ(fenBoard.zobristKey, moveBoard.zobristKey);
     EXPECT_NE(fenBoard.zobristKey, 0);
-    EXPECT_EQ(fenBoard.zobristKeyHistory.back(), fenBoard.zobristKey);
     EXPECT_EQ(fenBoard.isWhiteTurn, moveBoard.isWhiteTurn);
     EXPECT_EQ(fenBoard.castlingRights, moveBoard.castlingRights);
     EXPECT_EQ(fenBoard.pawnJumpedSquare, moveBoard.pawnJumpedSquare);
@@ -226,7 +223,7 @@ TEST_F(BoardTest, checkDiagAttackersTrue) {
         EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, WQueen    , EmptyPiece,
     };
     Board board(boardArr, false);
-    bool isAttacked = currKingInAttack(board);
+    bool isAttacked = currKingInAttack(board.pieceSets, board.isWhiteTurn);
     ASSERT_EQ(isAttacked, true);
 }
 
@@ -242,7 +239,7 @@ TEST_F(BoardTest, checkDiagAttackersFalse) {
         EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, BPawn     , EmptyPiece,
     };
     Board board(boardArr, false);
-    bool isAttacked = currKingInAttack(board);
+    bool isAttacked = currKingInAttack(board.pieceSets, board.isWhiteTurn);
     ASSERT_EQ(isAttacked, false);
 }
 
@@ -258,7 +255,7 @@ TEST_F(BoardTest, checkStraightAttackersTrue) {
         EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, BPawn     , EmptyPiece,
     };
     Board board(boardArr, false);
-    bool isAttacked = currKingInAttack(board);
+    bool isAttacked = currKingInAttack(board.pieceSets, board.isWhiteTurn);
     ASSERT_EQ(isAttacked, true);
 }
 
@@ -275,7 +272,7 @@ TEST_F(BoardTest, checkStraightAttackersFalse) {
         EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, BPawn     , EmptyPiece,
     };
     Board board(boardArr, false);
-    bool isAttacked = currKingInAttack(board);
+    bool isAttacked = currKingInAttack(board.pieceSets, board.isWhiteTurn);
     ASSERT_EQ(isAttacked, false);
 }
 
@@ -291,7 +288,7 @@ TEST_F(BoardTest, checkKnightAttackersTrue1) {
         EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, WKing     ,
     };
     Board board(boardArr, false);
-    bool isAttacked = currKingInAttack(board);
+    bool isAttacked = currKingInAttack(board.pieceSets, board.isWhiteTurn);
     ASSERT_EQ(isAttacked, true);
 }
 
@@ -307,7 +304,7 @@ TEST_F(BoardTest, checkKnightAttackersTrue2) {
         EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, WKing     ,
     };
     Board board(boardArr, false);
-    bool isAttacked = currKingInAttack(board);
+    bool isAttacked = currKingInAttack(board.pieceSets, board.isWhiteTurn);
     ASSERT_EQ(isAttacked, true);
 }
 
@@ -323,7 +320,7 @@ TEST_F(BoardTest, checkKnightAttackersTrue3) {
         EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, WKing     ,
     };
     Board board(boardArr, false);
-    bool isAttacked = currKingInAttack(board);
+    bool isAttacked = currKingInAttack(board.pieceSets, board.isWhiteTurn);
     ASSERT_EQ(isAttacked, true);
 }
 
@@ -339,7 +336,7 @@ TEST_F(BoardTest, checkKnightAttackersTrue4) {
         EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, WKing     ,
     };
     Board board(boardArr, false);
-    bool isAttacked = currKingInAttack(board);
+    bool isAttacked = currKingInAttack(board.pieceSets, board.isWhiteTurn);
     ASSERT_EQ(isAttacked, true);
 }
 
@@ -355,7 +352,7 @@ TEST_F(BoardTest, checkKnightAttackersFalse) {
         EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, WKnight   , EmptyPiece, EmptyPiece, WKing     ,
     };
     Board board(boardArr, false);
-    bool isAttacked = currKingInAttack(board);
+    bool isAttacked = currKingInAttack(board.pieceSets, board.isWhiteTurn);
     ASSERT_EQ(isAttacked, false);
 }
 
@@ -371,7 +368,7 @@ TEST_F(BoardTest, checkPawnAttackersTrue1) {
         EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, WKing     ,
     };
     Board board(boardArr, false);
-    bool isAttacked = currKingInAttack(board);
+    bool isAttacked = currKingInAttack(board.pieceSets, board.isWhiteTurn);
     ASSERT_EQ(isAttacked, true);
 }
 
@@ -387,7 +384,7 @@ TEST_F(BoardTest, checkPawnAttackersTrue2) {
         EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, WKing     ,
     };
     Board board(boardArr, false);
-    bool isAttacked = currKingInAttack(board);
+    bool isAttacked = currKingInAttack(board.pieceSets, board.isWhiteTurn);
     ASSERT_EQ(isAttacked, true);
 }
 
@@ -403,7 +400,7 @@ TEST_F(BoardTest, checkPawnAttackersFalse) {
         EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, WKing     ,
     };
     Board board(boardArr, false);
-    bool isAttacked = currKingInAttack(board);
+    bool isAttacked = currKingInAttack(board.pieceSets, board.isWhiteTurn);
     ASSERT_EQ(isAttacked, false);
 }
 
@@ -419,7 +416,7 @@ TEST_F(BoardTest, checkKingAttackersTrue1) {
         EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece,
     };
     Board board(boardArr, false);
-    bool isAttacked = currKingInAttack(board);
+    bool isAttacked = currKingInAttack(board.pieceSets, board.isWhiteTurn);
     ASSERT_EQ(isAttacked, true);
 }
 
@@ -435,7 +432,7 @@ TEST_F(BoardTest, checkKingAttackersTrue2) {
         EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece,
     };
     Board board(boardArr, false);
-    bool isAttacked = currKingInAttack(board);
+    bool isAttacked = currKingInAttack(board.pieceSets, board.isWhiteTurn);
     ASSERT_EQ(isAttacked, true);
 }
 
@@ -451,7 +448,7 @@ TEST_F(BoardTest, checkKingAttackersFalse) {
         EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, WKing     ,
     };
     Board board(boardArr, false);
-    bool isAttacked = currKingInAttack(board);
+    bool isAttacked = currKingInAttack(board.pieceSets, board.isWhiteTurn);
     ASSERT_EQ(isAttacked, false);
 }
 
@@ -467,7 +464,7 @@ TEST_F(BoardTest, inCheckTrue1) {
         EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, WKing     ,
     };
     Board board(boardArr, false);
-    bool isAttacked = currKingInAttack(board);
+    bool isAttacked = currKingInAttack(board.pieceSets, board.isWhiteTurn);
     ASSERT_EQ(isAttacked, true);
 }
 
@@ -483,7 +480,7 @@ TEST_F(BoardTest, inCheckTrue2) {
         EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, WKing     ,
     };
     Board board(boardArr, false);
-    bool isAttacked = currKingInAttack(board);
+    bool isAttacked = currKingInAttack(board.pieceSets, board.isWhiteTurn);
     ASSERT_EQ(isAttacked, true);
 }
 
@@ -495,7 +492,6 @@ TEST_F(BoardTest, BoardMoveConstructorPawnJump) {
     board.makeMove(pos1, pos2);
 
     EXPECT_EQ(board.isWhiteTurn, false);
-    EXPECT_EQ(board.isIllegalPos, false);
     EXPECT_EQ(board.getPiece(pos2), WPawn);
     EXPECT_EQ(board.pawnJumpedSquare, enPassantSquare);
     EXPECT_EQ(board.fiftyMoveRule, 0);
@@ -518,7 +514,6 @@ TEST_F(BoardTest, BoardMoveConstructorKingCastle) {
     board.makeMove(pos1, pos2);
 
     EXPECT_EQ(board.isWhiteTurn, false);
-    EXPECT_EQ(board.isIllegalPos, false);
     EXPECT_EQ(board.getPiece(pos1), EmptyPiece);
     EXPECT_EQ(board.getPiece(7, H), EmptyPiece);
     EXPECT_EQ(board.getPiece(7, F), WRook);
@@ -544,7 +539,6 @@ TEST_F(BoardTest, BoardMoveConstructorQueenCastle) {
     board.makeMove(pos1, pos2);
 
     EXPECT_EQ(board.isWhiteTurn, false);
-    EXPECT_EQ(board.isIllegalPos, false);
     EXPECT_EQ(board.getPiece(pos1), EmptyPiece);
     EXPECT_EQ(board.getPiece(7, A), EmptyPiece);
     EXPECT_EQ(board.getPiece(7, D), WRook);
@@ -570,7 +564,6 @@ TEST_F(BoardTest, BoardMoveConstructorMovedKing) {
     board.makeMove(pos1, pos2);
 
     EXPECT_EQ(board.isWhiteTurn, false);
-    EXPECT_EQ(board.isIllegalPos, false);
     EXPECT_EQ(board.getPiece(pos1), EmptyPiece);
     EXPECT_EQ(board.getPiece(7, A), WRook);
     EXPECT_EQ(board.getPiece(7, D), EmptyPiece);
@@ -597,7 +590,6 @@ TEST_F(BoardTest, BoardMoveConstructorKingToCastleSquare) {
     board.makeMove(pos1, pos2);
 
     EXPECT_EQ(board.isWhiteTurn, false);
-    EXPECT_EQ(board.isIllegalPos, false);
     EXPECT_EQ(board.getPiece(pos1), EmptyPiece);
     EXPECT_EQ(board.getPiece(pos2), WKing);
     EXPECT_EQ(board.getPiece(7, H), WRook);
@@ -615,7 +607,6 @@ TEST_F(BoardTest, BoardMoveConstructorEnPassant) {
     fenBoard.makeMove(pos1, pos2);
 
     EXPECT_EQ(fenBoard.isWhiteTurn, moveBoard.isWhiteTurn);
-    EXPECT_EQ(fenBoard.isIllegalPos, moveBoard.isIllegalPos);
     EXPECT_EQ(fenBoard.board, moveBoard.board);
     EXPECT_EQ(fenBoard.getPiece(pos1), EmptyPiece);
     EXPECT_EQ(fenBoard.getPiece(pos2), WPawn);
@@ -635,7 +626,6 @@ TEST_F(BoardTest, BoardMoveConstructorNotEnPassant) {
     fenBoard.makeMove(pos1, pos2);
 
     EXPECT_EQ(fenBoard.isWhiteTurn, moveBoard.isWhiteTurn);
-    EXPECT_EQ(fenBoard.isIllegalPos, moveBoard.isIllegalPos);
     EXPECT_EQ(fenBoard.board, moveBoard.board);
     EXPECT_EQ(fenBoard.pieceSets, moveBoard.pieceSets);
     EXPECT_EQ(fenBoard.pawnJumpedSquare, BoardSquare());
@@ -660,7 +650,6 @@ TEST_F(BoardTest, BoardMoveConstructorPromote) {
     board.makeMove(pos1, pos2, WQueen);
 
     EXPECT_EQ(board.isWhiteTurn, false);
-    EXPECT_EQ(board.isIllegalPos, false);
     EXPECT_EQ(board.getPiece(pos1), EmptyPiece);
     EXPECT_EQ(board.getPiece(pos2), WQueen);
     EXPECT_EQ(board.fiftyMoveRule, 0);
@@ -683,14 +672,13 @@ TEST_F(BoardTest, BoardMoveConstructorPawnCapture) {
     board.makeMove(pos1, pos2);
 
     EXPECT_EQ(board.isWhiteTurn, false);
-    EXPECT_EQ(board.isIllegalPos, false);
     EXPECT_EQ(board.getPiece(pos1), EmptyPiece);
     EXPECT_EQ(board.getPiece(pos2), WPawn);
     EXPECT_EQ(board.getPiece(3, E), BPawn);
     EXPECT_EQ(board.fiftyMoveRule, 0);
 }
 
-TEST_F(BoardTest, BoardMoveConstructorRegularCapture) {
+TEST_F(BoardTest, LegalMoveRegularCapture) {
     std::array<pieceTypes, BOARD_SIZE> boardArr = {
         EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece,
         EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, BPawn     , EmptyPiece, EmptyPiece,
@@ -707,13 +695,12 @@ TEST_F(BoardTest, BoardMoveConstructorRegularCapture) {
     board.makeMove(pos1, pos2);
 
     EXPECT_EQ(board.isWhiteTurn, false);
-    EXPECT_EQ(board.isIllegalPos, false);
     EXPECT_EQ(board.getPiece(pos1), EmptyPiece);
     EXPECT_EQ(board.getPiece(pos2), WBishop);
     EXPECT_EQ(board.fiftyMoveRule, 0);
 }
 
-TEST_F(BoardTest, BoardMoveConstructorRookPin) {
+TEST_F(BoardTest, LegalMoveRookPin) {
     std::array<pieceTypes, BOARD_SIZE> boardArr = {
         BRook     , EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, BKing     ,
         WRook     , EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece,
@@ -725,13 +712,12 @@ TEST_F(BoardTest, BoardMoveConstructorRookPin) {
         WKing     , EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece,
     };
     Board board(boardArr, true);
-    BoardSquare pos1 = BoardSquare(1, A);
-    BoardSquare pos2 = BoardSquare(1, B);
-    board.makeMove(pos1, pos2);
-    ASSERT_EQ(board.isIllegalPos, true);
+    std::cout << board << std::endl;
+    BoardMove move("a7b7", board.isWhiteTurn);
+    ASSERT_FALSE(board.isLegalMove(move));
 }
 
-TEST_F(BoardTest, BoardMoveConstructorBishopPin) {
+TEST_F(BoardTest, LegalMoveBishopPin) {
     std::array<pieceTypes, BOARD_SIZE> boardArr = {
         EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece,
         EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece,
@@ -743,10 +729,9 @@ TEST_F(BoardTest, BoardMoveConstructorBishopPin) {
         WKing     , EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece,
     };
     Board board(boardArr, true);
-    BoardSquare pos1 = BoardSquare(6, B);
-    BoardSquare pos2 = BoardSquare(5, A);
-    board.makeMove(pos1, pos2);
-    ASSERT_EQ(board.isIllegalPos, true);
+    std::cout << board << std::endl;
+    BoardMove move("b2a3", board.isWhiteTurn);
+    ASSERT_FALSE(board.isLegalMove(move));
 }
 
 TEST_F(BoardTest, BoardMoveConstructorCastleRightsRook) {
@@ -785,7 +770,6 @@ TEST_F(BoardTest, undoMove) {
     EXPECT_EQ(defaultBoard.board, moveBoard.board);
     EXPECT_EQ(defaultBoard.zobristKey, moveBoard.zobristKey);
     EXPECT_NE(defaultBoard.zobristKey, 0);
-    EXPECT_EQ(defaultBoard.zobristKeyHistory.back(), defaultBoard.zobristKey);
     EXPECT_EQ(defaultBoard.isWhiteTurn, moveBoard.isWhiteTurn);
     EXPECT_EQ(defaultBoard.castlingRights, moveBoard.castlingRights);
     EXPECT_EQ(defaultBoard.pawnJumpedSquare, moveBoard.pawnJumpedSquare);

--- a/tests/testMoveGen.cpp
+++ b/tests/testMoveGen.cpp
@@ -253,6 +253,7 @@ TEST_F(MoveGenTest, validKingMovesNoCastle) {
         WKing     , EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece,
     };
     Board board(boardArr);
+    board.castlingRights = noCastle;
     
     std::vector<BoardMove> validMoves;
     std::vector<BoardMove> expectedValidMoves = {


### PR DESCRIPTION
The current move generation implementation makes the move and checks for illegality to ensure only legal moves are generated. This is inefficient because legal moves can be performed multiple times: once in movegen and once in search. This is even more egregious because makeMove handles other incrementally updated parts and not all legal moves are made during search, leaving the bulk of runtime being in moveGen.

isLegalMove will only incrementally update the bitboards, which are the essential parts of understanding if a king is left in attack. This results in a large speedup.

![image](https://github.com/knguy22/Blocky-Chess-Engine/assets/77951761/f6fb8d7f-96cc-40fd-808f-a26825a9573b)

```
Advancement Test:

Time Control: 10s + 0.1s
Alpha: 0.05
Beta: 0.05
Elo0: 0
Elo1: 10
```
