### PR TITLE
En passant hotfix + UCI bug fixes

### DIFF
--- a/src/board.cpp
+++ b/src/board.cpp
@@ -429,19 +429,30 @@ bool Board::isLegalMove(const BoardMove move) const {
     assert(move.isValid());
 
     std::array<uint64_t, NUM_BITBOARDS> tmpPieceSets = this->pieceSets;
+
     pieceTypes originColor = this->isWhiteTurn ? WHITE_PIECES : BLACK_PIECES;
-
     uint64_t originSquare = (1ull << move.pos1.toSquare());
-    uint64_t targetSquare = (1ull << move.pos2.toSquare());
     pieceTypes originPiece = this->getPiece(move.pos1);
-    pieceTypes targetPiece = this->getPiece(move.pos2);
 
+    // account for all captures, including en passant
+    uint64_t targetSquare;
+    pieceTypes targetPiece;
+    pieceTypes allyPawn = this->isWhiteTurn ? WPawn : BPawn;
+    if (originPiece == allyPawn && move.pos2 == this->pawnJumpedSquare) {
+        int dir = this->isWhiteTurn ? 8 : -8;
+        targetSquare = 1ull << (move.pos2.toSquare() + dir);
+        targetPiece = this->isWhiteTurn ? BPawn : WPawn;
+    } else {
+        targetSquare = 1ull << move.pos2.toSquare();
+        targetPiece = this->getPiece(move.pos2);
+    }
     // move ally piece 
     tmpPieceSets[originColor] ^= originSquare;
     tmpPieceSets[originPiece] ^= originSquare;
     tmpPieceSets[originColor] ^= targetSquare;
     tmpPieceSets[originPiece] ^= targetSquare;
 
+    // check destination
     if (targetPiece != EmptyPiece) {
         pieceTypes targetColor = this->isWhiteTurn ? BLACK_PIECES : WHITE_PIECES;
         tmpPieceSets[targetColor] ^= targetSquare;

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -18,6 +18,7 @@ namespace Search {
         // perform iterative deepening
         for(int i = 1; i <= this->depth_limit; i++) {
             root = this->search(MIN_ALPHA, MAX_BETA, i, 0);
+            std::cout << i << ' ' << root.eval << std::endl;
             
             if(this->tm.timeUp()) {
                 result.nodes = this->nodes;
@@ -32,11 +33,11 @@ namespace Search {
         }
 
         // compute mate-in
-        if (root.eval > MAX_BETA - 100) {
-            result.mateIn = MAX_BETA - root.eval;
+        if (result.eval > MAX_BETA - 100) {
+            result.mateIn = MAX_BETA - result.eval;
         }
-        if (root.eval < MIN_ALPHA + 100) {
-            result.mateIn = root.eval - MIN_ALPHA;
+        if (result.eval < MIN_ALPHA + 100) {
+            result.mateIn = result.eval - MIN_ALPHA;
         }
         return result;
     }

--- a/src/search.hpp
+++ b/src/search.hpp
@@ -16,12 +16,12 @@ namespace Search {
 
     // used for outside UCI representation    
     struct Info {
-        uint64_t nodes;
-        int depth;
-        int eval;
+        uint64_t nodes = 0;
+        int depth = 0;
+        int eval = 0;
         int mateIn = NO_MATE;
         BoardMove move;
-        uint64_t timeElapsed;
+        uint64_t timeElapsed = 0;
     };
 
     // used for internal searching

--- a/tests/testBoard.cpp
+++ b/tests/testBoard.cpp
@@ -458,6 +458,12 @@ TEST_F(BoardTest, LegalMoveBishopPin) {
     ASSERT_FALSE(board.isLegalMove(move));
 }
 
+TEST_F(BoardTest, LegalMoveEnPassant) {
+    Board board("2RQ4/R6p/6b1/1k5p/Ppp5/8/6P1/7K b - a3 0 42");
+    BoardMove move("b4a3", board.isWhiteTurn);
+    ASSERT_TRUE(board.isLegalMove(move));
+}
+
 TEST_F(BoardTest, MakeMoveCastleRightsRook) {
     Board board("rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQK2R w KQkq - 0 1");
     board.makeMove(BoardMove("h1g1", board.isWhiteTurn));


### PR DESCRIPTION
LegalMove doesn't correctly handle en passant captures while the king is in check,. as shown in the fen given in the test case: 
`2RQ4/R6p/6b1/1k5p/Ppp5/8/6P1/7K b - a3 0 42`. This is an amendment to the function to now handle this correctly, though this comes at the cost of speed in the majority of positions. A regression test was ran, but it stopped prematurely due to main (not the hotfix) crashing:

```
Regression Test:
Time Control: 10s + 0.1s
WDL: +334 -337 =251

Alpha: 0.05
Beta: 0.05
Elo0: -15
Elo1: 0

Lower bound: -2.94444
Current LLR: 1.00449
Upper bound: 2.94444
```

There is also another bugfix which fixes the way mates are shown in info as well as nodes and depth in certain cases.