### PR TITLE
Attack Tables

### DIFF
--- a/src/attacks.cpp
+++ b/src/attacks.cpp
@@ -16,8 +16,11 @@ std::array<Magic, BOARD_SIZE> ROOK_TABLE;
 std::array<Magic, BOARD_SIZE> BISHOP_TABLE;
 std::array<uint64_t, 102400> ROOK_ATTACKS;
 std::array<uint64_t, 5248> BISHOP_ATTACKS;
+std::array<std::array<uint64_t, BOARD_SIZE>, 2> PAWN_ATTACKS;
+std::array<uint64_t, BOARD_SIZE> KNIGHT_ATTACKS;
+std::array<uint64_t, BOARD_SIZE> KING_ATTACKS;
 
-// functions
+// return attack table values
 uint64_t rookAttacks(int square, uint64_t allPieces) {
     return ROOK_ATTACKS[getMagicIndex(ROOK_TABLE[square], allPieces)];
 }
@@ -26,9 +29,33 @@ uint64_t bishopAttacks(int square, uint64_t allPieces) {
     return BISHOP_ATTACKS[getMagicIndex(BISHOP_TABLE[square], allPieces)];
 }
 
+uint64_t pawnAttacks(int square, bool isWhiteTurn) {
+    int color = isWhiteTurn ? 0 : 1;
+    return PAWN_ATTACKS[color][square];
+}
+
+uint64_t knightAttacks(int square) {
+    return KNIGHT_ATTACKS[square];
+}
+
+uint64_t kingAttacks(int square) {
+    return KING_ATTACKS[square];
+}
+
+// precompute attack table values
+
 void init() {
-    initMagicTable(ROOK_TABLE, ROOK_MAGICS, ROOK_ATTACKS, rookSlidingAttacks, false);
-    initMagicTable(BISHOP_TABLE, BISHOP_MAGICS, BISHOP_ATTACKS, bishopSlidingAttacks, true);
+    initMagicTable(ROOK_TABLE, ROOK_MAGICS, ROOK_ATTACKS, computeRookAttacks, false);
+    initMagicTable(BISHOP_TABLE, BISHOP_MAGICS, BISHOP_ATTACKS, computeBishopAttacks, true);
+
+    // init other tables
+    for (int i = 0; i < BOARD_SIZE; i++) {
+        KNIGHT_ATTACKS[i] = computeKnightAttacks(i);
+        KING_ATTACKS[i] = computeKingAttacks(i);
+        PAWN_ATTACKS[0][i] = computePawnAttacks(i, true);
+        PAWN_ATTACKS[1][i] = computePawnAttacks(i, false);
+    }
+
 }
 
 template <typename Function, size_t SIZE>
@@ -103,7 +130,7 @@ uint64_t getRelevantBlockerMask(int square, bool isBishop) {
     return slideMask;
 }
 
-uint64_t rookSlidingAttacks(int square, uint64_t blockers) {
+uint64_t computeRookAttacks(int square, uint64_t blockers) {
     uint64_t attacks = 0ull;
     attacks |= fillInDir(square, blockers, 0, 1);
     attacks |= fillInDir(square, blockers, 0, -1);
@@ -112,7 +139,7 @@ uint64_t rookSlidingAttacks(int square, uint64_t blockers) {
     return attacks;
 }
 
-uint64_t bishopSlidingAttacks(int square, uint64_t blockers) {
+uint64_t computeBishopAttacks(int square, uint64_t blockers) {
     uint64_t attacks = 0ull;
     attacks |= fillInDir(square, blockers, 1, 1);
     attacks |= fillInDir(square, blockers, 1, -1);
@@ -135,6 +162,47 @@ uint64_t fillInDir(int square, uint64_t blockers, int x, int y) {
         currY += y;
     }
     return filled;
+}
+
+uint64_t computeKnightAttacks(int square) {
+    uint64_t currPiece = 1ull << square;
+    uint64_t left1 = (currPiece >> 1) & NOT_FILE_H;
+    uint64_t left2 = (currPiece >> 2) & NOT_FILE_HG;
+    uint64_t right1 = (currPiece << 1) & NOT_FILE_A;
+    uint64_t right2 = (currPiece << 2) & NOT_FILE_AB;
+
+    uint64_t height1 = left1 | right1;
+    uint64_t height2 = left2 | right2;
+    
+    uint64_t knightSquares = (height1 << 16) | (height1 >> 16) | (height2 << 8) | (height2 >> 8);
+    return knightSquares;
+}
+
+uint64_t computeKingAttacks(int square) {
+    uint64_t currPiece = 1ull << square;
+
+    // prevent currPiece from teleporting to other side of the board with bit shifts
+    uint64_t left = currPiece & NOT_FILE_A;
+    uint64_t right = currPiece & NOT_FILE_H;
+    
+    currPiece |= (left >> 1);
+    currPiece |= (right << 1);
+    
+    // up one row and down one row respectively
+    currPiece |= (currPiece >> 8) | (currPiece << 8);
+    return currPiece;
+}
+
+uint64_t computePawnAttacks(int square, bool isWhiteTurn) {
+    uint64_t currPiece = 1ull << square;
+
+    // prevent currPiece from teleporting to other side of the board with bit shifts
+    uint64_t left  = currPiece & NOT_FILE_A;
+    uint64_t right = currPiece & NOT_FILE_H;
+    
+    uint64_t upPawns   = (left >> 9) | (right >> 7); 
+    uint64_t downPawns = (left << 7) | (right << 9); 
+    return isWhiteTurn ? upPawns : downPawns;
 }
 
 } // namespace Attacks

--- a/src/attacks.cpp
+++ b/src/attacks.cpp
@@ -43,12 +43,12 @@ uint64_t kingAttacks(int square) {
 }
 
 // precompute attack table values
-
 void init() {
+    // init rook and bishop tables
     initMagicTable(ROOK_TABLE, ROOK_MAGICS, ROOK_ATTACKS, computeRookAttacks, false);
     initMagicTable(BISHOP_TABLE, BISHOP_MAGICS, BISHOP_ATTACKS, computeBishopAttacks, true);
 
-    // init other tables
+    // init king, knight, and pawn tables
     for (int i = 0; i < BOARD_SIZE; i++) {
         KNIGHT_ATTACKS[i] = computeKnightAttacks(i);
         KING_ATTACKS[i] = computeKingAttacks(i);

--- a/src/attacks.hpp
+++ b/src/attacks.hpp
@@ -13,10 +13,14 @@ struct Magic {
     int offset;
 };
 
+// used to return attack table values
 uint64_t rookAttacks(int square, uint64_t allPieces);
 uint64_t bishopAttacks(int square, uint64_t allPieces);
+uint64_t pawnAttacks(int square, bool isWhiteTurn);
+uint64_t knightAttacks(int square);
+uint64_t kingAttacks(int square);
 
-// internal initialization
+// initilizes all tables 
 void init();
 template <typename Function, size_t SIZE>
 void initMagicTable(std::array<Magic, BOARD_SIZE>& table,
@@ -28,14 +32,22 @@ int getMagicIndex(Magic& entry, uint64_t blockers);
 uint64_t getRelevantBlockerMask(int square, bool isBishop);
 std::vector<uint64_t> getPossibleBlockers(uint64_t slideMask);
 
-uint64_t rookSlidingAttacks(int square, uint64_t blockers);
-uint64_t bishopSlidingAttacks(int square, uint64_t blockers);
+// bitboard functions
+uint64_t computeRookAttacks(int square, uint64_t blockers);
+uint64_t computeBishopAttacks(int square, uint64_t blockers);
 uint64_t fillInDir(int square, uint64_t blockers, int x, int y);
+uint64_t computeKnightAttacks(int square);
+uint64_t computeKingAttacks(int square);
+uint64_t computePawnAttacks(int square, bool isWhiteTurn);
 
+// table declarations
 extern std::array<Magic, BOARD_SIZE> ROOK_TABLE;
 extern std::array<Magic, BOARD_SIZE> BISHOP_TABLE;
 extern std::array<uint64_t, 102400> ROOK_ATTACKS;
 extern std::array<uint64_t, 5248> BISHOP_ATTACKS;
+extern std::array<std::array<uint64_t, BOARD_SIZE>, 2> PAWN_ATTACKS;
+extern std::array<uint64_t, BOARD_SIZE> KNIGHT_ATTACKS;
+extern std::array<uint64_t, BOARD_SIZE> KING_ATTACKS;
 
 // see ../tools/magic.cpp for how these magic numbers were generated
 constexpr std::array<uint64_t, BOARD_SIZE> ROOK_MAGICS{

--- a/src/bitboard.cpp
+++ b/src/bitboard.cpp
@@ -66,46 +66,6 @@ uint64_t getAntiDiagMask(int square) {
     return flipVertical(DIAGS_MASK[7 - getRank(square) + getFile(square)]);
 }
 
-uint64_t knightSquares(uint64_t knights) {
-    uint64_t left1 = (knights >> 1) & NOT_FILE_H;
-    uint64_t left2 = (knights >> 2) & NOT_FILE_HG;
-    uint64_t right1 = (knights << 1) & NOT_FILE_A;
-    uint64_t right2 = (knights << 2) & NOT_FILE_AB;
-
-    uint64_t height1 = left1 | right1;
-    uint64_t height2 = left2 | right2;
-    
-    uint64_t knightSquares = (height1 << 16) | (height1 >> 16) | (height2 << 8) | (height2 >> 8);
-    return knightSquares;
-}
-
-bool pawnAttackers(int square, uint64_t enemyPawns, bool isWhiteTurn) {
-    uint64_t currPiece = 1ull << square;
-
-    // prevent currPiece from teleporting to other side of the board with bit shifts
-    uint64_t left  = currPiece & NOT_FILE_A;
-    uint64_t right = currPiece & NOT_FILE_H;
-    
-    uint64_t upPawns   = (left >> 9) | (right >> 7); 
-    uint64_t downPawns = (left << 7) | (right << 9); 
-    return isWhiteTurn ? upPawns & enemyPawns : downPawns & enemyPawns;
-}
-
-bool kingAttackers(int square, uint64_t enemyKings) {
-    uint64_t currPiece = 1ull << square;
-
-    // prevent currPiece from teleporting to other side of the board with bit shifts
-    uint64_t left = currPiece & NOT_FILE_A;
-    uint64_t right = currPiece & NOT_FILE_H;
-    
-    currPiece |= (left >> 1);
-    currPiece |= (right << 1);
-    
-    // up one row and down one row respectively
-    currPiece |= (currPiece >> 8) | (currPiece << 8);
-    return currPiece & enemyKings;
-}
-
 // below functions are for debugging and testing
 
 void printHex(uint64_t bitboard) {

--- a/src/bitboard.hpp
+++ b/src/bitboard.hpp
@@ -72,10 +72,6 @@ uint64_t getRankMask(int square);
 uint64_t getDiagMask(int square);
 uint64_t getAntiDiagMask(int square);
 
-uint64_t knightSquares(uint64_t knights);
-bool pawnAttackers(int square, uint64_t enemyPawns, bool isWhiteTurn);
-bool kingAttackers(int square, uint64_t enemyKings);
-
 // for debugging and testing
 void printHex(uint64_t bitboard);
 void printBitboard(uint64_t bitboard);

--- a/src/board.cpp
+++ b/src/board.cpp
@@ -580,9 +580,9 @@ bool currKingInAttack(std::array<uint64_t, NUM_BITBOARDS>& pieceSets, bool isWhi
 
     return Attacks::bishopAttacks(kingSquare, allPieces) & (enemyBishops | enemyQueens)
         || Attacks::rookAttacks(kingSquare, allPieces) & (enemyRooks | enemyQueens)
-        || knightSquares(enemyKnights) & 1ull << kingSquare
-        || pawnAttackers(kingSquare, enemyPawns, isWhiteTurn)
-        || kingAttackers(kingSquare, enemyKings);
+        || Attacks::pawnAttacks(kingSquare, isWhiteTurn) & enemyPawns
+        || Attacks::knightAttacks(kingSquare) & enemyKnights
+        || Attacks::kingAttacks(kingSquare) & enemyKings;
 }
 
 // used for debugging

--- a/src/board.cpp
+++ b/src/board.cpp
@@ -564,7 +564,7 @@ castleRights castleRightsBit(BoardSquare finalKingPos, bool isWhiteTurn) {
     }
 }
 
-bool currKingInAttack(std::array<uint64_t, NUM_BITBOARDS>& pieceSets, bool isWhiteTurn) {
+bool currKingInAttack(const std::array<uint64_t, NUM_BITBOARDS>& pieceSets, bool isWhiteTurn) {
     pieceTypes allyKing = isWhiteTurn ? WKing : BKing;
     assert(pieceSets[allyKing]);
     int kingSquare = leadingBit(pieceSets[allyKing]);

--- a/src/board.hpp
+++ b/src/board.hpp
@@ -80,7 +80,7 @@ struct Board {
 };
 
 castleRights castleRightsBit(BoardSquare finalKingPos, bool isWhiteTurn);
-bool currKingInAttack(std::array<uint64_t, NUM_BITBOARDS>& pieceSets, bool isWhiteTurn);
+bool currKingInAttack(const std::array<uint64_t, NUM_BITBOARDS>& pieceSets, bool isWhiteTurn);
 
 // for debugging
 uint64_t makeBitboardFromArray(std::array<pieceTypes, BOARD_SIZE> board, int target);

--- a/src/moveGen.cpp
+++ b/src/moveGen.cpp
@@ -96,7 +96,7 @@ namespace MOVEGEN {
             int square = popLeadingBit(knights);
             BoardSquare knight(square);
             uint64_t knightBitboard = 1ull << square;
-            uint64_t knightMoves = knightSquares(knightBitboard) & ~allies;
+            uint64_t knightMoves = Attacks::knightAttacks(square) & ~allies;
             while (knightMoves) {
                 int currSquare = popLeadingBit(knightMoves);
                 BoardMove move(knight, BoardSquare(currSquare));
@@ -110,11 +110,11 @@ namespace MOVEGEN {
 
     void validBishopMoves(Board& currBoard, std::vector<BoardMove>& validMoves, uint64_t bishops) {
         uint64_t allPieces = currBoard.pieceSets[WHITE_PIECES] | currBoard.pieceSets[BLACK_PIECES];
-        uint64_t friendlyPieces = currBoard.isWhiteTurn ? currBoard.pieceSets[WHITE_PIECES] : currBoard.pieceSets[BLACK_PIECES];
+        uint64_t allies = currBoard.isWhiteTurn ? currBoard.pieceSets[WHITE_PIECES] : currBoard.pieceSets[BLACK_PIECES];
         while (bishops) {
             int square = popLeadingBit(bishops);
             BoardSquare bishop(square);
-            uint64_t bishopMoves = Attacks::bishopAttacks(square, allPieces) & ~friendlyPieces;
+            uint64_t bishopMoves = Attacks::bishopAttacks(square, allPieces) & ~allies;
             while (bishopMoves) {
                 int currSquare = popLeadingBit(bishopMoves);
                 BoardMove move(bishop, BoardSquare(currSquare));
@@ -127,11 +127,11 @@ namespace MOVEGEN {
 
     void validRookMoves(Board& currBoard, std::vector<BoardMove>& validMoves, uint64_t rooks) {
         uint64_t allPieces = currBoard.pieceSets[WHITE_PIECES] | currBoard.pieceSets[BLACK_PIECES];
-        uint64_t friendlyPieces = currBoard.isWhiteTurn ? currBoard.pieceSets[WHITE_PIECES] : currBoard.pieceSets[BLACK_PIECES];
+        uint64_t allies = currBoard.isWhiteTurn ? currBoard.pieceSets[WHITE_PIECES] : currBoard.pieceSets[BLACK_PIECES];
         while (rooks) {
             int square = popLeadingBit(rooks);
             BoardSquare rook(square);
-            uint64_t rookMoves = Attacks::rookAttacks(square, allPieces) & ~friendlyPieces;
+            uint64_t rookMoves = Attacks::rookAttacks(square, allPieces) & ~allies;
             while (rookMoves) {
                 int currSquare = popLeadingBit(rookMoves);
                 BoardMove move(rook, BoardSquare(currSquare));

--- a/src/moveGen.cpp
+++ b/src/moveGen.cpp
@@ -6,267 +6,191 @@
 #include <stdexcept>
 #include <iostream>
 
-namespace MOVEGEN {
+namespace MoveGen {
 
-    std::vector<BoardMove> moveGenerator(Board currBoard) {
-        std::vector<BoardMove> listOfMoves;
-        
-        uint64_t kings   = currBoard.isWhiteTurn ? currBoard.pieceSets[WKing]   : currBoard.pieceSets[BKing]; 
-        uint64_t pawns   = currBoard.isWhiteTurn ? currBoard.pieceSets[WPawn]   : currBoard.pieceSets[BPawn];
-        uint64_t knights = currBoard.isWhiteTurn ? currBoard.pieceSets[WKnight] : currBoard.pieceSets[BKnight];
-        uint64_t bishops = currBoard.isWhiteTurn ? currBoard.pieceSets[WBishop] : currBoard.pieceSets[BBishop];
-        uint64_t rooks   = currBoard.isWhiteTurn ? currBoard.pieceSets[WRook]   : currBoard.pieceSets[BRook];
-        uint64_t queens  = currBoard.isWhiteTurn ? currBoard.pieceSets[WQueen]  : currBoard.pieceSets[BQueen];
+std::vector<BoardMove> moveGenerator(Board board) {
+    std::vector<BoardMove> listOfMoves;
+    
+    // get all required helper bitboards for fast move generation
+    MoveGenInfo info;
+    info.allPieces = board.pieceSets[WHITE_PIECES] | board.pieceSets[BLACK_PIECES];
+    info.emptySquares = ~info.allPieces;
+    info.notAllies  = board.isWhiteTurn ? ~board.pieceSets[WHITE_PIECES] : ~board.pieceSets[BLACK_PIECES]; 
+    info.isWhiteTurn = board.isWhiteTurn;
 
-        validPawnMoves(currBoard, listOfMoves, pawns);
-        validKnightMoves(currBoard, listOfMoves, knights);
-        validBishopMoves(currBoard, listOfMoves, bishops);
-        validRookMoves(currBoard, listOfMoves, rooks);
-        validQueenMoves(currBoard, listOfMoves, queens);
-        validKingMoves(currBoard, listOfMoves, kings);
-        return listOfMoves;
+    // helper bitboards for pawn generation 
+    info.pawnEnemies = board.isWhiteTurn ? board.pieceSets[BLACK_PIECES] : board.pieceSets[WHITE_PIECES]; 
+    info.pawnEnemies |= board.pawnJumpedSquare != BoardSquare() ? 1ull << board.pawnJumpedSquare.toSquare() : 0ull;
+    info.pawnStartRank = board.isWhiteTurn ? RANK_2 : RANK_7;
+    info.pawnJumpRank  = board.isWhiteTurn ? RANK_4 : RANK_5;
+
+    // helper bitboards for king castling
+    info.pieceSets = board.pieceSets;
+    info.castlingRights = board.castlingRights;
+    info.castlingRights &= board.isWhiteTurn ? W_Castle : B_Castle;
+    
+    // gather piece bitboards
+    uint64_t kings   = board.isWhiteTurn ? board.pieceSets[WKing]   : board.pieceSets[BKing]; 
+    uint64_t pawns   = board.isWhiteTurn ? board.pieceSets[WPawn]   : board.pieceSets[BPawn];
+    uint64_t knights = board.isWhiteTurn ? board.pieceSets[WKnight] : board.pieceSets[BKnight];
+    uint64_t bishops = board.isWhiteTurn ? board.pieceSets[WBishop] : board.pieceSets[BBishop];
+    uint64_t rooks   = board.isWhiteTurn ? board.pieceSets[WRook]   : board.pieceSets[BRook];
+    uint64_t queens  = board.isWhiteTurn ? board.pieceSets[WQueen]  : board.pieceSets[BQueen];
+
+    // generate moves
+    validPawnMoves(pawns, info, board, listOfMoves);
+    validPieceMoves(knights, knightMoves, info, board, listOfMoves);
+    validPieceMoves(bishops, bishopMoves, info, board, listOfMoves);
+    validPieceMoves(rooks, rookMoves, info, board, listOfMoves);
+    validPieceMoves(queens, bishopMoves, info, board, listOfMoves);
+    validPieceMoves(queens, rookMoves, info, board, listOfMoves);
+    validPieceMoves(kings, kingMoves, info, board, listOfMoves);
+
+    return listOfMoves;
+}
+
+template<typename Func>
+void validPieceMoves(uint64_t pieces, Func pieceMoves, MoveGenInfo& info, Board& board, std::vector<BoardMove>& validMoves) {
+    while (pieces) {
+        int square = popLeadingBit(pieces);
+        BoardSquare piece(square);
+
+        uint64_t moves = pieceMoves(square, info);
+        while (moves) {
+            int currSquare = popLeadingBit(moves);
+            BoardMove move(piece, BoardSquare(currSquare));
+            if (board.isLegalMove(move)) {
+                validMoves.push_back(move);
+            }
+        }
     }
+}
 
-    void validPawnMoves(Board& currBoard, std::vector<BoardMove>& validMoves, uint64_t pawns) {
-        int promoteRank = currBoard.isWhiteTurn ? 0 : 7;
-        pieceTypes allyKnight = currBoard.isWhiteTurn ? WKnight : BKnight;
-        pieceTypes allyBishop = currBoard.isWhiteTurn ? WBishop : BBishop;
-        pieceTypes allyRook = currBoard.isWhiteTurn ? WRook : BRook;
-        pieceTypes allyQueen = currBoard.isWhiteTurn ? WQueen : BQueen;
+void validPawnMoves(uint64_t pawns, MoveGenInfo& info, Board& board, std::vector<BoardMove>& validMoves) {
+    int promoteRank = board.isWhiteTurn ? 0 : 7;
+    pieceTypes allyKnight = board.isWhiteTurn ? WKnight : BKnight;
+    pieceTypes allyBishop = board.isWhiteTurn ? WBishop : BBishop;
+    pieceTypes allyRook = board.isWhiteTurn ? WRook : BRook;
+    pieceTypes allyQueen = board.isWhiteTurn ? WQueen : BQueen;
 
-        while (pawns) {
-            BoardSquare pawn(popLeadingBit(pawns));
-            std::vector<BoardSquare> pawnMoves;
+    while (pawns) {
+        int square = popLeadingBit(pawns);
+        BoardSquare pawn(square);
+        uint64_t moves = pawnMoves(square, info, board.isWhiteTurn);
 
-            forwardPawnMoves(currBoard, pawnMoves, pawn);
-            pawnCaptures(currBoard, pawnMoves, pawn, 1);
-            pawnCaptures(currBoard, pawnMoves, pawn, -1);        
-        
-            for (BoardSquare target: pawnMoves) {
-                if (!currBoard.isLegalMove(BoardMove(pawn, target))) {
-                    continue;
-                } 
-                if (target.rank == promoteRank) {
-                    validMoves.push_back(BoardMove(pawn, target, allyKnight));
-                    validMoves.push_back(BoardMove(pawn, target, allyBishop));
-                    validMoves.push_back(BoardMove(pawn, target, allyRook));
-                    validMoves.push_back(BoardMove(pawn, target, allyQueen));
+        while (moves) {
+            BoardSquare target(popLeadingBit(moves));
+            if (!board.isLegalMove(BoardMove(pawn, target))) {
+                continue;
+            } 
+            if (target.rank == promoteRank) {
+                validMoves.push_back(BoardMove(pawn, target, allyKnight));
+                validMoves.push_back(BoardMove(pawn, target, allyBishop));
+                validMoves.push_back(BoardMove(pawn, target, allyRook));
+                validMoves.push_back(BoardMove(pawn, target, allyQueen));
+            }
+            else {
+                validMoves.push_back(BoardMove(pawn, target));
+            }
+        }
+    }
+}
+
+uint64_t knightMoves(int square, MoveGenInfo& info) {
+    return Attacks::knightAttacks(square) & info.notAllies;
+}
+
+uint64_t bishopMoves(int square, MoveGenInfo& info) {
+    return Attacks::bishopAttacks(square, info.allPieces) & info.notAllies;
+}
+
+uint64_t rookMoves(int square, MoveGenInfo& info) {
+    return Attacks::rookAttacks(square, info.allPieces) & info.notAllies;
+}
+
+uint64_t kingMoves(int square, MoveGenInfo& info) {
+    // regular moves
+    uint64_t moves = Attacks::kingAttacks(square) & info.notAllies;
+    
+    // castling
+    // test if the king is in check; castling is illegal in check
+    if (!currKingInAttack(info.pieceSets, info.isWhiteTurn)) {
+        int kingIndex = info.isWhiteTurn ? WKing : BKing;
+
+        while (info.castlingRights) {
+            bool castleBlocked = false;
+            int currRight = popLeadingBit(info.castlingRights);
+            uint64_t path = castlePaths[currRight];
+
+            // check each square for emptiness and being attacked
+            while (path) {
+                int currSquare = popLeadingBit(path);
+                info.pieceSets[kingIndex] = 1ull << currSquare;
+                if (1ull << currSquare & info.allPieces || 
+                    currKingInAttack(info.pieceSets, info.isWhiteTurn)) {
+                    castleBlocked = true;
+                    break;
                 }
-                else {
-                    validMoves.push_back(BoardMove(pawn, target));
-                }
+            }
+
+            if (!castleBlocked) {
+                moves |= castleDestination[currRight];
             }
         }
     }
 
+    return moves;
+}
 
-    void forwardPawnMoves(Board& currBoard, std::vector<BoardSquare>& pawnMoves, BoardSquare pawn) {
-        int pawnDirection = currBoard.isWhiteTurn ? -1 : 1;
-        int originRank = currBoard.isWhiteTurn ? 6 : 1;
-
-        // any spaces forward
-        if (currBoard.getPiece(pawn.rank + pawnDirection, pawn.file) == EmptyPiece) {
-            pawnMoves.push_back(BoardSquare(pawn.rank + pawnDirection, pawn.file));
-            // jump
-            if (pawn.rank == originRank) {
-                if (currBoard.getPiece(pawn.rank + pawnDirection * 2, pawn.file) == EmptyPiece) {
-                    pawnMoves.push_back(BoardSquare(pawn.rank + pawnDirection * 2, pawn.file));
-            }
-        }
-        }
+uint64_t pawnMoves(int square, MoveGenInfo& bitboards, bool isWhiteTurn) {
+    uint64_t moves, pawn = 1ull << square;
+    uint64_t currFile = FILES_MASK[getFile(square)];
+    // one space forward
+    if (isWhiteTurn) {
+        moves = (pawn >> 8) & bitboards.emptySquares;
+    } else {
+        moves = (pawn << 8) & bitboards.emptySquares;
+    } 
+    // two spaces forward
+    if (pawn & bitboards.pawnStartRank && moves) {
+        moves |= (currFile & bitboards.pawnJumpRank) & bitboards.emptySquares;
     }
+    // captures
+    moves |= Attacks::pawnAttacks(square, isWhiteTurn) & bitboards.pawnEnemies;
+    return moves;
+}
 
-    void pawnCaptures(Board& currBoard, std::vector<BoardSquare>& pawnMoves, BoardSquare pawn, int fileDirection) {
-        int pawnDirection = currBoard.isWhiteTurn ? -1 : 1;
-
-        BoardSquare square = BoardSquare(pawn.rank + pawnDirection, pawn.file + fileDirection);
-        // regular capture
-        if (square.isValid() && !isFriendlyPiece(currBoard, square) && currBoard.getPiece(square) != EmptyPiece) {
-            pawnMoves.push_back(square);
-        }
-        // en passant
-        if (square == currBoard.pawnJumpedSquare) {
-            pawnMoves.push_back(square);
-        }
+// perft is a method of determining correctness of move generators
+// positions can be input and number of total leaf nodes determined
+// the number determined can be compared to a table to established values from others
+uint64_t perft(Board board, int depthLeft) {
+    if (depthLeft == 0) {
+        return 1;
     }
-
-    void validKnightMoves(Board& currBoard, std::vector<BoardMove>& validMoves, uint64_t knights) {
-        uint64_t allies = currBoard.isWhiteTurn ? currBoard.pieceSets[WHITE_PIECES] : currBoard.pieceSets[BLACK_PIECES];
-        while (knights) {
-            int square = popLeadingBit(knights);
-            BoardSquare knight(square);
-            uint64_t knightBitboard = 1ull << square;
-            uint64_t knightMoves = Attacks::knightAttacks(square) & ~allies;
-            while (knightMoves) {
-                int currSquare = popLeadingBit(knightMoves);
-                BoardMove move(knight, BoardSquare(currSquare));
-                if (currBoard.isLegalMove(move)) {
-                    validMoves.push_back(move);
-                }
-            }
-
-        }
+    uint64_t leafNodeCount = 0;
+    std::vector<BoardMove> moves = moveGenerator(board);
+    for (auto move: moves) {
+        board.makeMove(move);
+        uint64_t moveCount = perftHelper(board, depthLeft - 1);
+        leafNodeCount += moveCount;
+        std::cout << move << ": " << moveCount << std::endl; 
+        board.undoMove();
     }
+    return leafNodeCount;
+}
 
-    void validBishopMoves(Board& currBoard, std::vector<BoardMove>& validMoves, uint64_t bishops) {
-        uint64_t allPieces = currBoard.pieceSets[WHITE_PIECES] | currBoard.pieceSets[BLACK_PIECES];
-        uint64_t allies = currBoard.isWhiteTurn ? currBoard.pieceSets[WHITE_PIECES] : currBoard.pieceSets[BLACK_PIECES];
-        while (bishops) {
-            int square = popLeadingBit(bishops);
-            BoardSquare bishop(square);
-            uint64_t bishopMoves = Attacks::bishopAttacks(square, allPieces) & ~allies;
-            while (bishopMoves) {
-                int currSquare = popLeadingBit(bishopMoves);
-                BoardMove move(bishop, BoardSquare(currSquare));
-                if (currBoard.isLegalMove(move)) {
-                    validMoves.push_back(move);
-                }
-            }
-        }
+uint64_t perftHelper(Board board, int depthLeft) {
+    if (depthLeft == 0) {
+        return 1;
     }
-
-    void validRookMoves(Board& currBoard, std::vector<BoardMove>& validMoves, uint64_t rooks) {
-        uint64_t allPieces = currBoard.pieceSets[WHITE_PIECES] | currBoard.pieceSets[BLACK_PIECES];
-        uint64_t allies = currBoard.isWhiteTurn ? currBoard.pieceSets[WHITE_PIECES] : currBoard.pieceSets[BLACK_PIECES];
-        while (rooks) {
-            int square = popLeadingBit(rooks);
-            BoardSquare rook(square);
-            uint64_t rookMoves = Attacks::rookAttacks(square, allPieces) & ~allies;
-            while (rookMoves) {
-                int currSquare = popLeadingBit(rookMoves);
-                BoardMove move(rook, BoardSquare(currSquare));
-                if (currBoard.isLegalMove(move)) {
-                    validMoves.push_back(move);
-                }
-            }
-        }
+    uint64_t leafNodeCount = 0;
+    std::vector<BoardMove> moves = moveGenerator(board);
+    for (auto move: moves) {
+        board.makeMove(move);
+        leafNodeCount += perftHelper(board, depthLeft - 1);
+        board.undoMove();
     }
+    return leafNodeCount;
+}
 
-    void validQueenMoves(Board& currBoard, std::vector<BoardMove>& validMoves, uint64_t queens) {
-        validBishopMoves(currBoard, validMoves, queens);
-        validRookMoves(currBoard, validMoves, queens);
-    }
-
-
-    void validKingMoves(Board& currBoard, std::vector<BoardMove>& validMoves, uint64_t kings) {
-        int kingUnmovedRank = currBoard.isWhiteTurn ? 7 : 0;
-        
-        while (kings) {
-            BoardSquare king(popLeadingBit(kings));
-            int currRank = king.rank;
-            fileVals currFile = king.file;
-            std::vector<BoardSquare> kingMoves;
-            std::vector<BoardSquare> potentialAdjacentMoves = {
-                BoardSquare(currRank - 1, currFile - 1),
-                BoardSquare(currRank - 1, currFile),
-                BoardSquare(currRank - 1, currFile + 1),
-                BoardSquare(currRank + 1, currFile - 1),
-                BoardSquare(currRank + 1, currFile),
-                BoardSquare(currRank + 1, currFile + 1),
-                BoardSquare(currRank, currFile - 1),
-                BoardSquare(currRank, currFile + 1),
-            };
-            std::vector<BoardSquare> potentialCastleMoves = {
-                BoardSquare(currRank, currFile - 2),
-                BoardSquare(currRank, currFile + 2),
-            };
-            // regular movements
-            for (BoardSquare square: potentialAdjacentMoves) {
-                if (square.isValid() && !isFriendlyPiece(currBoard, square)) {
-                    kingMoves.push_back(square);
-                }
-            }
-            // castling
-            for (BoardSquare square: potentialCastleMoves) {
-                // check for castling rights and validity
-                if (currKingInAttack(currBoard.pieceSets, currBoard.isWhiteTurn)) {break;}
-                if (!(currBoard.castlingRights & castleRightsBit(square, currBoard.isWhiteTurn))) {continue;}
-
-
-                // prevent castling through squares attacked by enemies
-                int kingFileDirection = square.file == G ? 1 : -1;
-                BoardMove oneOver(king, BoardSquare(king.rank, king.file + kingFileDirection));
-                if (!currBoard.isLegalMove(oneOver)) {
-                    continue;
-                }
-
-                // check for pieces in between king and rook
-                if (unblockedCastleRook(currBoard, king, kingFileDirection)) {
-                    kingMoves.push_back(BoardSquare(kingUnmovedRank, square.file));
-                }
-            }
-
-            for (BoardSquare target: kingMoves) {
-                BoardMove move(king, target);
-                if (!target.isValid()) {
-                    continue;
-                }
-                if (currBoard.isLegalMove(move)) {
-                    validMoves.push_back(move);
-                }
-            }
-
-        }
-    }
-
-    bool unblockedCastleRook(Board& currBoard, BoardSquare king, int xDir) {
-        int currFile = king.file + xDir;
-        int targetFile = xDir == 1 ? H : A;
-        pieceTypes allyRook = currBoard.isWhiteTurn ? WRook : BRook;
-
-        while (currFile >= A && currFile <= H) {
-            pieceTypes currPiece = currBoard.getPiece(king.rank, currFile);
-            if (currPiece == allyRook) {
-                break;
-            }
-            else if (currPiece != EmptyPiece) {
-                return false;
-            }
-            currFile += xDir;
-        }
-        return currFile == targetFile;
-    }
-
-    bool isFriendlyPiece(Board& currBoard, BoardSquare targetSquare) {
-        int target = currBoard.getPiece(targetSquare);
-        if(currBoard.isWhiteTurn) {
-            return target >= WKing && target <= WPawn;
-        }
-        else {
-            return target >= BKing && target <= BPawn;
-        }
-    }
-
-    // perft is a method of determining correctness of move generators
-    // positions can be input and number of total leaf nodes determined
-    // the number determined can be compared to a table to established values from others
-    uint64_t perft(Board board, int depthLeft) {
-        if (depthLeft == 0) {
-            return 1;
-        }
-        uint64_t leafNodeCount = 0;
-        std::vector<BoardMove> moves = moveGenerator(board);
-        for (auto move: moves) {
-            board.makeMove(move);
-            uint64_t moveCount = perftHelper(board, depthLeft - 1);
-            leafNodeCount += moveCount;
-            std::cout << move << ": " << moveCount << std::endl; 
-            board.undoMove();
-        }
-        return leafNodeCount;
-    }
-
-    uint64_t perftHelper(Board board, int depthLeft) {
-        if (depthLeft == 0) {
-            return 1;
-        }
-        uint64_t leafNodeCount = 0;
-        std::vector<BoardMove> moves = moveGenerator(board);
-        for (auto move: moves) {
-            board.makeMove(move);
-            leafNodeCount += perftHelper(board, depthLeft - 1);
-            board.undoMove();
-        }
-        return leafNodeCount;
-    }
-} // namespace MOVEGEN
+} // namespace MoveGen

--- a/src/moveGen.cpp
+++ b/src/moveGen.cpp
@@ -118,24 +118,24 @@ uint64_t kingMoves(int square, MoveGenInfo& info) {
         int kingIndex = info.isWhiteTurn ? WKing : BKing;
 
         while (info.castlingRights) {
-            bool castleBlocked = false;
             int currRight = popLeadingBit(info.castlingRights);
-            uint64_t path = castlePaths[currRight];
 
-            // check each square for emptiness and being attacked
-            while (path) {
-                int currSquare = popLeadingBit(path);
-                info.pieceSets[kingIndex] = 1ull << currSquare;
-                if (1ull << currSquare & info.allPieces || 
-                    currKingInAttack(info.pieceSets, info.isWhiteTurn)) {
-                    castleBlocked = true;
-                    break;
-                }
+            // check for emptiness between rook and king
+            if (rookPaths[currRight] & info.allPieces) {
+                continue;
             }
 
-            if (!castleBlocked) {
-                moves |= castleDestination[currRight];
+            // check for king path being attacked
+            uint64_t path = kingPaths[currRight];
+            int currSquare = popLeadingBit(path);
+            info.pieceSets[kingIndex] = 1ull << currSquare;
+            if (1ull << currSquare & info.allPieces || 
+                currKingInAttack(info.pieceSets, info.isWhiteTurn)) {
+                    continue;
             }
+
+            // perform castle
+            moves |= castleDestination[currRight];
         }
     }
 

--- a/src/moveGen.hpp
+++ b/src/moveGen.hpp
@@ -1,27 +1,42 @@
 #pragma once
 
+#include <array>
 #include <cstdint>
 #include <vector>
 
 #include "board.hpp"
 
-namespace MOVEGEN {
+namespace MoveGen {
 
-    std::vector<BoardMove> moveGenerator(Board currBoard); // outputs board instead of board moves for future evaluation functions
-    void validPawnMoves(Board& currBoard, std::vector<BoardMove>& validMoves, uint64_t pawns); // includes en passant
-    void validKnightMoves(Board& currBoard, std::vector<BoardMove>& validMoves, uint64_t knights);
-    void validBishopMoves(Board& currBoard, std::vector<BoardMove>& validMoves, uint64_t bishops);
-    void validRookMoves(Board& currBoard, std::vector<BoardMove>& validMoves, uint64_t rooks);
-    void validQueenMoves(Board& currBoard, std::vector<BoardMove>& validMoves, uint64_t queens);
-    void validKingMoves(Board& currBoard, std::vector<BoardMove>& validMoves, uint64_t kings); // includes castling
+struct MoveGenInfo {
+    uint64_t allPieces, emptySquares, notAllies; 
+    uint64_t pawnEnemies, pawnStartRank, pawnJumpRank;
+    std::array<uint64_t, NUM_BITBOARDS> pieceSets;
+    uint64_t castlingRights;
+    bool isWhiteTurn;
+};
 
-    bool unblockedCastleRook(Board& currBoard, BoardSquare king, int xDir); 
-    bool isFriendlyPiece(Board& currBoard, BoardSquare targetSquare);
+std::vector<BoardMove> moveGenerator(Board board); // outputs board instead of board moves for future evaluation functions
 
-    void forwardPawnMoves(Board& currBoard, std::vector<BoardSquare>& pawnMoves, BoardSquare pawn);
-    void pawnCaptures(Board& currBoard, std::vector<BoardSquare>& pawnMoves, BoardSquare pawn, int fileDirection);
+template<typename Func>
+void validPieceMoves(uint64_t pieces, Func pieceMoves, MoveGenInfo& colors, Board& board, std::vector<BoardMove>& validMoves);
+void validPawnMoves(uint64_t pawns, MoveGenInfo& colors, Board& board, std::vector<BoardMove>& validMoves); // includes en passant
 
-    // for debugging
-    uint64_t perft(Board board, int depthLeft);
-    uint64_t perftHelper(Board currBoard, int depthLeft);
-} // namespace MOVEGEN
+uint64_t knightMoves(int square, MoveGenInfo& info);
+uint64_t bishopMoves(int square, MoveGenInfo& info);
+uint64_t rookMoves(int square, MoveGenInfo& info);
+uint64_t kingMoves(int square, MoveGenInfo& info);
+uint64_t pawnMoves(int square, MoveGenInfo& info, bool isWhiteTurn);
+
+// indexes based on castle rights defined in "types.hpp"
+constexpr std::array<uint64_t, 4> castlePaths = {
+    0x6000000000000000ull, 0x0C00000000000000ull, 0x0000000000000060ull, 0x000000000000000Cull};
+constexpr std::array<uint64_t, 4> castleDestination = {
+    0x4000000000000000ull, 0x0400000000000000ull, 0x0000000000000040ull, 0x0000000000000004ull};
+
+// for debugging
+uint64_t perft(Board board, int depthLeft);
+uint64_t perftHelper(Board board, int depthLeft);
+
+
+} // namespace MoveGen

--- a/src/moveGen.hpp
+++ b/src/moveGen.hpp
@@ -29,8 +29,10 @@ uint64_t kingMoves(int square, MoveGenInfo& info);
 uint64_t pawnMoves(int square, MoveGenInfo& info, bool isWhiteTurn);
 
 // indexes based on castle rights defined in "types.hpp"
-constexpr std::array<uint64_t, 4> castlePaths = {
-    0x6000000000000000ull, 0x0C00000000000000ull, 0x0000000000000060ull, 0x000000000000000Cull};
+constexpr std::array<uint64_t, 4> rookPaths = {
+    0x6000000000000000ull, 0x0E00000000000000ull, 0x0000000000000060ull, 0x000000000000000Eull};
+constexpr std::array<uint64_t, 4> kingPaths = {
+    0x2000000000000000ull, 0x0800000000000000ull, 0x0000000000000020ull, 0x0000000000000008ull};
 constexpr std::array<uint64_t, 4> castleDestination = {
     0x4000000000000000ull, 0x0400000000000000ull, 0x0000000000000040ull, 0x0000000000000004ull};
 

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -71,7 +71,7 @@ namespace Search {
             return result;
         }
         // checkmate or stalemate
-        std::vector<BoardMove> moves = MOVEGEN::moveGenerator(this->board);
+        std::vector<BoardMove> moves = MoveGen::moveGenerator(this->board);
         if (moves.size() == 0) {
             if (currKingInAttack(board.pieceSets, board.isWhiteTurn)) {
                 result.eval = MIN_ALPHA + distanceFromRoot;
@@ -128,7 +128,7 @@ namespace Search {
         if(depthLeft == 0)
             return stand_pat;
 
-        std::vector<BoardMove> moves = MOVEGEN::moveGenerator(this->board);
+        std::vector<BoardMove> moves = MoveGen::moveGenerator(this->board);
         MovePicker movePicker(std::move(moves));
         movePicker.assignMoveScores(board);
 

--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -144,7 +144,7 @@ namespace Uci {
         
         // perform perft
         auto start = std::chrono::high_resolution_clock::now();
-        uint64_t nodes = MOVEGEN::perft(board, depth);
+        uint64_t nodes = MoveGen::perft(board, depth);
         auto end = std::chrono::high_resolution_clock::now();
         int64_t duration = std::chrono::duration_cast<std::chrono::microseconds>(end - start).count();
         std::cout << "perft result nodes " << nodes;

--- a/tests/testBitBoard.cpp
+++ b/tests/testBitBoard.cpp
@@ -1,4 +1,6 @@
+#include "attacks.hpp"
 #include "bitboard.hpp"
+#include "move.hpp"
 #include "types.hpp"
 
 #include <gtest/gtest.h>
@@ -6,86 +8,93 @@
 #include <bitset>
 #include <cstdint>
 
-TEST(BitboardTest, leadingBitEmpty) {
+class BitboardTest : public testing::Test {
+    public:
+        static void SetUpTestSuite() {
+            Attacks::init();
+        }
+};
+
+TEST_F(BitboardTest, leadingBitEmpty) {
     uint64_t bitboard = 0ull;
     ASSERT_DEATH({leadingBit(bitboard);}, "");
 }
 
-TEST(BitboardTest, leadingBitOne) {
+TEST_F(BitboardTest, leadingBitOne) {
     uint64_t bitboard = 1ull;
     ASSERT_EQ(leadingBit(bitboard), 0);
 }
 
-TEST(BitboardTest, leadingBitTrailingOne) {
+TEST_F(BitboardTest, leadingBitTrailingOne) {
     uint64_t bitboard = 0x8000000000000000ull;
     ASSERT_EQ(leadingBit(bitboard), 63);
 }
 
-TEST(BitboardTest, leadingBitMiddleOne) {
+TEST_F(BitboardTest, leadingBitMiddleOne) {
     uint64_t bitboard = 0x0000000000001000ull;
     ASSERT_EQ(leadingBit(bitboard), 12);
 }
 
-TEST(BitboardTest, leadingBitMultOnes) {
+TEST_F(BitboardTest, leadingBitMultOnes) {
     uint64_t bitboard = 0x0000001000100000ull;
     ASSERT_EQ(leadingBit(bitboard), 20);
 }
 
-TEST(BitboardTest, trailingBitEmpty) {
+TEST_F(BitboardTest, trailingBitEmpty) {
     uint64_t bitboard = 0ull;
     ASSERT_DEATH({trailingBit(bitboard);}, "");
 }
 
-TEST(BitboardTest, trailingBitOne) {
+TEST_F(BitboardTest, trailingBitOne) {
     uint64_t bitboard = 0x8000000000000000ull;
     ASSERT_EQ(trailingBit(bitboard), 0);
 }
 
-TEST(BitboardTest, trailingBitForwardOne) {
+TEST_F(BitboardTest, trailingBitForwardOne) {
     uint64_t bitboard = 0x0000000000000001ull;
     ASSERT_EQ(trailingBit(bitboard), 63);
 }
 
-TEST(BitboardTest, trailingBitMiddleOne) {
+TEST_F(BitboardTest, trailingBitMiddleOne) {
     uint64_t bitboard = 0x0008000000000000ull;
     ASSERT_EQ(trailingBit(bitboard), 12);
 }
 
-TEST(BitboardTest, trailingBitMultOnes) {
+TEST_F(BitboardTest, trailingBitMultOnes) {
     uint64_t bitboard = 0x0000080010000000ull;
     ASSERT_EQ(trailingBit(bitboard), 20);
 }
 
-TEST(BitboardTest, popLeadingBit1) {
+TEST_F(BitboardTest, popLeadingBit1) {
     uint64_t bitboard = 0x0000001000100000ull;
     ASSERT_EQ(popLeadingBit(bitboard), 20);
     ASSERT_EQ(bitboard, 0x0000001000000000ull);
 }
 
-TEST(BitboardTest, popTrailingBit1) {
+TEST_F(BitboardTest, popTrailingBit1) {
     uint64_t bitboard = 0x0000080010000000ull;
     ASSERT_EQ(popTrailingBit(bitboard), 20);
     ASSERT_EQ(bitboard, 0x0000000010000000ull);
 }
 
-TEST(BitboardTest, FlipVerticalEmpty) {
+TEST_F(BitboardTest, FlipVerticalEmpty) {
     uint64_t bitboard = 0x0000000000000000ull;
     ASSERT_EQ(flipVertical(bitboard), 0ull);
 }
 
-TEST(BitboardTest, FlipVerticalOne) {
+TEST_F(BitboardTest, FlipVerticalOne) {
     uint64_t bitboard = 0x0000000000000001ull;
     uint64_t expected = 0x0100000000000000ull;
     ASSERT_EQ(flipVertical(bitboard), expected);
 }
 
-TEST(BitboardTest, FlipVerticalMul) {
+TEST_F(BitboardTest, FlipVerticalMul) {
     uint64_t bitboard = 0x0000000000008421ull;
     uint64_t expected = 0x2184000000000000ull;
     ASSERT_EQ(flipVertical(bitboard), expected);
 }
 
-TEST(BitboardTest, getFileMaskTest) {
+TEST_F(BitboardTest, getFileMaskTest) {
     EXPECT_EQ(getFileMask(0), FILE_A);
     EXPECT_EQ(getFileMask(1), FILE_B);
     EXPECT_EQ(getFileMask(2), FILE_C);
@@ -97,7 +106,7 @@ TEST(BitboardTest, getFileMaskTest) {
     EXPECT_EQ(getFileMask(8), FILE_A);
 }
 
-TEST(BitboardTest, getRankMaskTest) {
+TEST_F(BitboardTest, getRankMaskTest) {
     EXPECT_EQ(getRankMask(0), RANK_8);
     EXPECT_EQ(getRankMask(8), RANK_7);
     EXPECT_EQ(getRankMask(16), RANK_6);
@@ -109,7 +118,7 @@ TEST(BitboardTest, getRankMaskTest) {
     EXPECT_EQ(getRankMask(5), RANK_8);
 }
 
-TEST(BitboardTest, getDiagMaskTest) {
+TEST_F(BitboardTest, getDiagMaskTest) {
     EXPECT_EQ(getDiagMask(0 ), DIAG_0);
     EXPECT_EQ(getDiagMask(8 ), DIAG_1);
     EXPECT_EQ(getDiagMask(16), DIAG_2);
@@ -128,207 +137,94 @@ TEST(BitboardTest, getDiagMaskTest) {
     EXPECT_EQ(getDiagMask(1 ), DIAG_1);
 }
 
-TEST(BitboardTest, knightAttacks1) {
-    std::array<pieceTypes, BOARD_SIZE> enemiesBoard = {
-        WKnight   , EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece,
-        EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece,
-        EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece,
-        EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece,
-        EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece,
-        EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece,
-        EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece,
-        EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece,
-    };
-
-    uint64_t enemies = arrayToBitboardNotEmpty(enemiesBoard);
-    uint64_t knightBitboard = knightAttacks(enemies);
+TEST_F(BitboardTest, knightAttacks1) {
+    uint64_t knightBitboard = Attacks::knightAttacks(BoardSquare("a8").toSquare());
     EXPECT_EQ(knightBitboard, 0x0000000000020400ull);
 }
 
-TEST(BitboardTest, knightAttacks2) {
-    std::array<pieceTypes, BOARD_SIZE> enemiesBoard = {
-        EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece,
-        EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece,
-        EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece,
-        EmptyPiece, WKnight   , EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece,
-        EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece,
-        EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece,
-        EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece,
-        EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece,
-    };
-
-    uint64_t enemies = arrayToBitboardNotEmpty(enemiesBoard);
-    uint64_t knightBitboard = knightAttacks(enemies);
+TEST_F(BitboardTest, knightAttacks2) {
+    uint64_t knightBitboard = Attacks::knightAttacks(BoardSquare("b5").toSquare());
     EXPECT_EQ(knightBitboard, 0x0000050800080500ull);
 }
 
-TEST(BitboardTest, knightAttacks3) {
-    std::array<pieceTypes, BOARD_SIZE> enemiesBoard = {
-        EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece,
-        EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece,
-        EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece,
-        EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece,
-        EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece,
-        EmptyPiece, WKnight   , EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece,
-        EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece,
-        EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece,
-    };
-
-    uint64_t enemies = arrayToBitboardNotEmpty(enemiesBoard);
-    uint64_t knightBitboard = knightAttacks(enemies);
+TEST_F(BitboardTest, knightAttacks3) {
+    uint64_t knightBitboard = Attacks::knightAttacks(BoardSquare("b3").toSquare());
     EXPECT_EQ(knightBitboard, 0x0508000805000000ull);
 }
 
-TEST(BitboardTest, knightAttacks4) {
-    std::array<pieceTypes, BOARD_SIZE> enemiesBoard = {
-        EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece,
-        EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece,
-        EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece,
-        EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece,
-        EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece,
-        EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece,
-        EmptyPiece, EmptyPiece, WKnight   , EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece,
-        EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece,
-    };
-
-    uint64_t enemies = arrayToBitboardNotEmpty(enemiesBoard);
-    uint64_t knightBitboard = knightAttacks(enemies);
+TEST_F(BitboardTest, knightAttacks4) {
+    uint64_t knightBitboard = Attacks::knightAttacks(BoardSquare("c2").toSquare());
     EXPECT_EQ(knightBitboard, 0x1100110A00000000ull);
 }
 
-TEST(BitboardTest, knightAttacks5) {
-    std::array<pieceTypes, BOARD_SIZE> enemiesBoard = {
-        EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece,
-        EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece,
-        EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece,
-        EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece,
-        EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece,
-        EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece,
-        EmptyPiece, EmptyPiece, EmptyPiece, WKnight   , EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece,
-        EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, WKnight   , EmptyPiece, EmptyPiece, EmptyPiece,
-    };
-
-    uint64_t enemies = arrayToBitboardNotEmpty(enemiesBoard);
-    uint64_t knightBitboard = knightAttacks(enemies);
-    EXPECT_EQ(knightBitboard, 0x22442A1400000000ull);
+TEST_F(BitboardTest, knightAttacks5) {
+    uint64_t knightBitboard1 = Attacks::knightAttacks(BoardSquare("d2").toSquare());
+    uint64_t knightBitboard2 = Attacks::knightAttacks(BoardSquare("e1").toSquare());
+    EXPECT_EQ(knightBitboard1 | knightBitboard2, 0x22442A1400000000ull);
 }
 
-TEST(BitboardTest, pawnAttackersTrue1) {
-    std::array<pieceTypes, BOARD_SIZE> enemiesBoard = {
-        EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece,
-        EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece,
-        EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece,
-        EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece,
-        EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece,
-        EmptyPiece, EmptyPiece, WPawn     , EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece,
-        EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece,
-        EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, WQueen    , EmptyPiece,
-    };
-
-    int rank = 4, file = 3;
-    int square = rank * 8 + file;
-
-    uint64_t enemies = arrayToBitboardNotEmpty(enemiesBoard);
-
-    EXPECT_EQ(pawnAttackers(square, enemies, false), true);
+TEST_F(BitboardTest, pawnAttackersTrue1) {
+    uint64_t square = 1ull << BoardSquare("d4").toSquare();
+    uint64_t pawnBitboard = Attacks::pawnAttacks(BoardSquare("c3").toSquare(), true);
+    ASSERT_TRUE(square & pawnBitboard);
 }
 
-TEST(BitboardTest, pawnAttackersTrue2) {
-    std::array<pieceTypes, BOARD_SIZE> enemiesBoard = {
-        EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece,
-        EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece,
-        EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece,
-        EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece,
-        EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece,
-        EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, WPawn     , EmptyPiece, EmptyPiece, EmptyPiece,
-        EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece,
-        EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece,
-    };
-
-    int rank = 4, file = 3;
-    int square = rank * 8 + file;
-
-    uint64_t enemies = arrayToBitboardNotEmpty(enemiesBoard);
-
-    EXPECT_EQ(pawnAttackers(square, enemies, false), true);
+TEST_F(BitboardTest, pawnAttackersTrue2) {
+    uint64_t square = 1ull << BoardSquare("d4").toSquare();
+    uint64_t pawnBitboard = Attacks::pawnAttacks(BoardSquare("e3").toSquare(), true);
+    ASSERT_TRUE(square & pawnBitboard);
 }
 
-TEST(BitboardTest, pawnAttackersFalse) {
-    std::array<pieceTypes, BOARD_SIZE> enemiesBoard = {
-        EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece,
-        EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece,
-        EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece,
-        EmptyPiece, EmptyPiece, WPawn     , EmptyPiece, WPawn     , EmptyPiece, EmptyPiece, EmptyPiece,
-        EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece,
-        EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece,
-        EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece,
-        EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece,
-    };
-
-    int rank = 4, file = 3;
-    int square = rank * 8 + file;
-
-    uint64_t enemies = arrayToBitboardNotEmpty(enemiesBoard);
-
-    EXPECT_EQ(pawnAttackers(square, enemies, false), false);
+TEST_F(BitboardTest, pawnAttackersTrue3) {
+    uint64_t square = 1ull << BoardSquare("d4").toSquare();
+    uint64_t pawnBitboard = Attacks::pawnAttacks(BoardSquare("c5").toSquare(), false);
+    ASSERT_TRUE(square & pawnBitboard);
 }
 
-TEST(BitboardTest, kingAttackersTrue1) {
-    std::array<pieceTypes, BOARD_SIZE> enemiesBoard = {
-        EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece,
-        EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece,
-        EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece,
-        EmptyPiece, EmptyPiece, WKing     , EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece,
-        EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece,
-        EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece,
-        EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece,
-        EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece,
-    };
-
-    int rank = 4, file = 3;
-    int square = rank * 8 + file;
-
-    uint64_t enemies = arrayToBitboardNotEmpty(enemiesBoard);
-
-    EXPECT_EQ(kingAttackers(square, enemies), true);
+TEST_F(BitboardTest, pawnAttackersTrue4) {
+    uint64_t square = 1ull << BoardSquare("d4").toSquare();
+    uint64_t pawnBitboard = Attacks::pawnAttacks(BoardSquare("e5").toSquare(), false);
+    ASSERT_TRUE(square & pawnBitboard);
 }
 
-TEST(BitboardTest, kingAttackersTrue2) {
-    std::array<pieceTypes, BOARD_SIZE> enemiesBoard = {
-        EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece,
-        EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece,
-        EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece,
-        EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece,
-        EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece,
-        EmptyPiece, EmptyPiece, WKing     , EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece,
-        EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece,
-        EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece,
-    };
-
-    int rank = 4, file = 3;
-    int square = rank * 8 + file;
-
-    uint64_t enemies = arrayToBitboardNotEmpty(enemiesBoard);
-
-    EXPECT_EQ(kingAttackers(square, enemies), true);
+TEST_F(BitboardTest, pawnAttackersFalse1) {
+    uint64_t square = 1ull << BoardSquare("d4").toSquare();
+    uint64_t pawnBitboard = Attacks::pawnAttacks(BoardSquare("c5").toSquare(), true);
+    ASSERT_FALSE(square & pawnBitboard);
 }
 
-TEST(BitboardTest, kingAttackersFalse) {
-    std::array<pieceTypes, BOARD_SIZE> enemiesBoard = {
-        EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece,
-        EmptyPiece, WKing     , EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece,
-        EmptyPiece, EmptyPiece, WKing     , EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece,
-        EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece,
-        EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece,
-        EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece,
-        EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece,
-        EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece,
-    };
+TEST_F(BitboardTest, pawnAttackersFalse2) {
+    uint64_t square = 1ull << BoardSquare("d4").toSquare();
+    uint64_t pawnBitboard = Attacks::pawnAttacks(BoardSquare("e5").toSquare(), true);
+    ASSERT_FALSE(square & pawnBitboard);
+}
 
-    int rank = 4, file = 3;
-    int square = rank * 8 + file;
+TEST_F(BitboardTest, pawnAttackersFalse3) {
+    uint64_t square = 1ull << BoardSquare("d4").toSquare();
+    uint64_t pawnBitboard = Attacks::pawnAttacks(BoardSquare("c3").toSquare(), false);
+    ASSERT_FALSE(square & pawnBitboard);
+}
 
-    uint64_t enemies = arrayToBitboardNotEmpty(enemiesBoard);
+TEST_F(BitboardTest, pawnAttackersFalse4) {
+    uint64_t square = 1ull << BoardSquare("d4").toSquare();
+    uint64_t pawnBitboard = Attacks::pawnAttacks(BoardSquare("e3").toSquare(), false);
+    ASSERT_FALSE(square & pawnBitboard);
+}
 
-    EXPECT_EQ(kingAttackers(square, enemies), false);
+TEST_F(BitboardTest, kingAttackersTrue1) {
+    uint64_t square = 1ull << BoardSquare("d4").toSquare();
+    uint64_t kingBitboard = Attacks::kingAttacks(BoardSquare("c5").toSquare());
+    ASSERT_TRUE(square & kingBitboard);
+}
+
+TEST_F(BitboardTest, kingAttackersTrue2) {
+    uint64_t square = 1ull << BoardSquare("d4").toSquare();
+    uint64_t kingBitboard = Attacks::kingAttacks(BoardSquare("c3").toSquare());
+    ASSERT_TRUE(square & kingBitboard);
+}
+
+TEST_F(BitboardTest, kingAttackersFalse) {
+    uint64_t square = 1ull << BoardSquare("d4").toSquare();
+    uint64_t kingBitboard = Attacks::kingAttacks(BoardSquare("c6").toSquare());
+    ASSERT_FALSE(square & kingBitboard);
 }

--- a/tests/testBitBoard.cpp
+++ b/tests/testBitBoard.cpp
@@ -128,7 +128,7 @@ TEST(BitboardTest, getDiagMaskTest) {
     EXPECT_EQ(getDiagMask(1 ), DIAG_1);
 }
 
-TEST(BitboardTest, knightSquares1) {
+TEST(BitboardTest, knightAttacks1) {
     std::array<pieceTypes, BOARD_SIZE> enemiesBoard = {
         WKnight   , EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece,
         EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece,
@@ -141,11 +141,11 @@ TEST(BitboardTest, knightSquares1) {
     };
 
     uint64_t enemies = arrayToBitboardNotEmpty(enemiesBoard);
-    uint64_t knightBitboard = knightSquares(enemies);
+    uint64_t knightBitboard = knightAttacks(enemies);
     EXPECT_EQ(knightBitboard, 0x0000000000020400ull);
 }
 
-TEST(BitboardTest, knightSquares2) {
+TEST(BitboardTest, knightAttacks2) {
     std::array<pieceTypes, BOARD_SIZE> enemiesBoard = {
         EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece,
         EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece,
@@ -158,11 +158,11 @@ TEST(BitboardTest, knightSquares2) {
     };
 
     uint64_t enemies = arrayToBitboardNotEmpty(enemiesBoard);
-    uint64_t knightBitboard = knightSquares(enemies);
+    uint64_t knightBitboard = knightAttacks(enemies);
     EXPECT_EQ(knightBitboard, 0x0000050800080500ull);
 }
 
-TEST(BitboardTest, knightSquares3) {
+TEST(BitboardTest, knightAttacks3) {
     std::array<pieceTypes, BOARD_SIZE> enemiesBoard = {
         EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece,
         EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece,
@@ -175,11 +175,11 @@ TEST(BitboardTest, knightSquares3) {
     };
 
     uint64_t enemies = arrayToBitboardNotEmpty(enemiesBoard);
-    uint64_t knightBitboard = knightSquares(enemies);
+    uint64_t knightBitboard = knightAttacks(enemies);
     EXPECT_EQ(knightBitboard, 0x0508000805000000ull);
 }
 
-TEST(BitboardTest, knightSquares4) {
+TEST(BitboardTest, knightAttacks4) {
     std::array<pieceTypes, BOARD_SIZE> enemiesBoard = {
         EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece,
         EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece,
@@ -192,11 +192,11 @@ TEST(BitboardTest, knightSquares4) {
     };
 
     uint64_t enemies = arrayToBitboardNotEmpty(enemiesBoard);
-    uint64_t knightBitboard = knightSquares(enemies);
+    uint64_t knightBitboard = knightAttacks(enemies);
     EXPECT_EQ(knightBitboard, 0x1100110A00000000ull);
 }
 
-TEST(BitboardTest, knightSquares5) {
+TEST(BitboardTest, knightAttacks5) {
     std::array<pieceTypes, BOARD_SIZE> enemiesBoard = {
         EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece,
         EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece,
@@ -209,7 +209,7 @@ TEST(BitboardTest, knightSquares5) {
     };
 
     uint64_t enemies = arrayToBitboardNotEmpty(enemiesBoard);
-    uint64_t knightBitboard = knightSquares(enemies);
+    uint64_t knightBitboard = knightAttacks(enemies);
     EXPECT_EQ(knightBitboard, 0x22442A1400000000ull);
 }
 

--- a/tests/testMoveGen.cpp
+++ b/tests/testMoveGen.cpp
@@ -8,7 +8,7 @@
 #include <algorithm>
 #include <vector>
 
-using namespace MOVEGEN;
+using namespace MoveGen;
 class MoveGenTest : public testing::Test {
     public:
         static void SetUpTestSuite() {
@@ -420,17 +420,17 @@ TEST_F(MoveGenTest, moveGeneratorBlackMove) {
 
 TEST_F(MoveGenTest, perftStartpos) {
     Board board;
-    ASSERT_EQ(MOVEGEN::perft(board, 0), 1);
-    ASSERT_EQ(MOVEGEN::perft(board, 1), 20);
-    ASSERT_EQ(MOVEGEN::perft(board, 2), 400);
-    ASSERT_EQ(MOVEGEN::perft(board, 3), 8902);
-    ASSERT_EQ(MOVEGEN::perft(board, 4), 197281);
+    ASSERT_EQ(MoveGen::perft(board, 0), 1);
+    ASSERT_EQ(MoveGen::perft(board, 1), 20);
+    ASSERT_EQ(MoveGen::perft(board, 2), 400);
+    ASSERT_EQ(MoveGen::perft(board, 3), 8902);
+    ASSERT_EQ(MoveGen::perft(board, 4), 197281);
 }
 
 TEST_F(MoveGenTest, perftKiwipete) {
     Board board("r3k2r/p1ppqpb1/bn2pnp1/3PN3/1p2P3/2N2Q1p/PPPBBPPP/R3K2R w KQkq - 0 1");
-    ASSERT_EQ(MOVEGEN::perft(board, 1), 48);
-    ASSERT_EQ(MOVEGEN::perft(board, 2), 2039);
-    ASSERT_EQ(MOVEGEN::perft(board, 3), 97862);
-    ASSERT_EQ(MOVEGEN::perft(board, 4), 4085603);
+    ASSERT_EQ(MoveGen::perft(board, 1), 48);
+    ASSERT_EQ(MoveGen::perft(board, 2), 2039);
+    ASSERT_EQ(MoveGen::perft(board, 3), 97862);
+    ASSERT_EQ(MoveGen::perft(board, 4), 4085603);
 }

--- a/tests/testMoveGen.cpp
+++ b/tests/testMoveGen.cpp
@@ -17,354 +17,64 @@ class MoveGenTest : public testing::Test {
         }
 };
 
-TEST_F(MoveGenTest, isFriendlyPieceTrue1) {
-    Board board;
-    BoardSquare whiteSquare = BoardSquare(7, H);
-    bool result = isFriendlyPiece(board, whiteSquare);
-    ASSERT_EQ(result, true);
-}
-
-TEST_F(MoveGenTest, isFriendlyPieceTrue2) {
-    Board board;
-    board.isWhiteTurn = false;
-    BoardSquare blackSquare = BoardSquare(1, H);
-    bool result = isFriendlyPiece(board, blackSquare);
-    ASSERT_EQ(result, true);
-}
-
-TEST_F(MoveGenTest, isFriendlyPieceFalse) {
-    Board board;
-    BoardSquare blackSquare = BoardSquare(1, H);
-    bool result = isFriendlyPiece(board, blackSquare);
-    ASSERT_EQ(result, false);
-}
-
-// there must be a king in each test to see for illegal moves
-
 TEST_F(MoveGenTest, validPawnMovesCaptures) {
-    std::array<pieceTypes, BOARD_SIZE> boardArr = {
-        EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece,
-        EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece,
-        EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece,
-        BPawn     , EmptyPiece, BPawn     , EmptyPiece, WQueen    , EmptyPiece, EmptyPiece, EmptyPiece,
-        WKing     , WPawn     , EmptyPiece, WPawn     , EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece,
-        EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece,
-        EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, WPawn     , EmptyPiece,
-        EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece,
-    };
-    Board board(boardArr);
-    
-    std::vector<BoardMove> validMoves;
-    std::vector<BoardMove> expectedValidMoves = {
-        BoardMove(BoardSquare(4, B), BoardSquare(3, A)),
-        BoardMove(BoardSquare(4, B), BoardSquare(3, B)),
-        BoardMove(BoardSquare(4, B), BoardSquare(3, C)),
-
-        BoardMove(BoardSquare(4, D), BoardSquare(3, C)),
-        BoardMove(BoardSquare(4, D), BoardSquare(3, D)),
-
-        BoardMove(BoardSquare(6, G), BoardSquare(5, G)),
-        BoardMove(BoardSquare(6, G), BoardSquare(4, G)),
-    };
-    uint64_t whitePawns = arrayToBitboardPieceType(boardArr, WPawn);
-    validPawnMoves(board, validMoves, whitePawns);
-
-    std::sort(validMoves.begin(), validMoves.end());
-    std::sort(expectedValidMoves.begin(), expectedValidMoves.end());
-    ASSERT_EQ(validMoves, expectedValidMoves);
+    Board board("7k/8/8/p1p14/KP1P4/8/6P1/8 w - - 0 1");
+    std::vector<BoardMove> moves = MoveGen::moveGenerator(board);
+    ASSERT_EQ(moves.size(), 11);
 }
 
 TEST_F(MoveGenTest, validPawnMovesPromotion) {
-    std::array<pieceTypes, BOARD_SIZE> boardArr = {
-        EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece,
-        EmptyPiece, EmptyPiece, EmptyPiece, WPawn     , EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece,
-        EmptyPiece, EmptyPiece, EmptyPiece, WKing     , EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece,
-        EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece,
-        EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece,
-        EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece,
-        EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece,
-        EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece,
-    };
-    Board board(boardArr);
-    
-    std::vector<BoardMove> validMoves;
-    std::vector<BoardMove> expectedValidMoves = {
-        BoardMove(BoardSquare(1, D), BoardSquare(0, D), WKnight),
-        BoardMove(BoardSquare(1, D), BoardSquare(0, D), WBishop),
-        BoardMove(BoardSquare(1, D), BoardSquare(0, D), WRook),
-        BoardMove(BoardSquare(1, D), BoardSquare(0, D), WQueen),
-    };
-    uint64_t whitePawns = arrayToBitboardPieceType(boardArr, WPawn);
-    validPawnMoves(board, validMoves, whitePawns);
-
-    std::sort(validMoves.begin(), validMoves.end());
-    std::sort(expectedValidMoves.begin(), expectedValidMoves.end());
-    ASSERT_EQ(validMoves, expectedValidMoves);
+    Board board("8/3P4/3K4/8/8/8/8/7k w - - 0 1");
+    std::vector<BoardMove> moves = MoveGen::moveGenerator(board);
+    ASSERT_EQ(moves.size(), 11);
 }
 
 TEST_F(MoveGenTest, validKnightMoves1) {
-    std::array<pieceTypes, BOARD_SIZE> boardArr = {
-        EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece,
-        EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece,
-        EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece,
-        EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece,
-        EmptyPiece, EmptyPiece, EmptyPiece, WKnight   , EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece,
-        EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece,
-        EmptyPiece, EmptyPiece, BKnight   , EmptyPiece, WKing     , EmptyPiece, EmptyPiece, EmptyPiece,
-        WKnight   , EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece,
-    };
-    Board board(boardArr);
-    
-    std::vector<BoardMove> validMoves;
-    std::vector<BoardMove> expectedValidMoves = {
-        BoardMove(BoardSquare(7, A), BoardSquare(5, B)),
-        BoardMove(BoardSquare(7, A), BoardSquare(6, C)),
-        
-        BoardMove(BoardSquare(4, D), BoardSquare(6, C)),
-        // BoardMove(BoardSquare(4, D), BoardSquare(6, E)), King located here
-        BoardMove(BoardSquare(4, D), BoardSquare(2, C)),
-        BoardMove(BoardSquare(4, D), BoardSquare(2, E)),
-        BoardMove(BoardSquare(4, D), BoardSquare(5, F)),
-        BoardMove(BoardSquare(4, D), BoardSquare(5, B)),
-        BoardMove(BoardSquare(4, D), BoardSquare(3, F)),
-        BoardMove(BoardSquare(4, D), BoardSquare(3, B)),
-    };
-    uint64_t whiteKnights = arrayToBitboardPieceType(boardArr, WKnight);
-    validKnightMoves(board, validMoves, whiteKnights);
-
-    std::sort(validMoves.begin(), validMoves.end());
-    std::sort(expectedValidMoves.begin(), expectedValidMoves.end());
-    ASSERT_EQ(validMoves, expectedValidMoves);
+    Board board("7k/8/8/8/3N4/8/2n1K3/N7 w - - 0 1");
+    std::vector<BoardMove> moves = MoveGen::moveGenerator(board);
+    ASSERT_EQ(moves.size(), 15);
 }
 
 TEST_F(MoveGenTest, validRookMoves1) {
-    std::array<pieceTypes, BOARD_SIZE> boardArr = {
-        WBishop   , WBishop   , EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece,
-        EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece,
-        EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece,
-        EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece,
-        EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece,
-        EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece,
-        EmptyPiece, EmptyPiece, WKing     , EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece,
-        WRook     , WRook     , EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, BRook     ,
-    };
-    Board board(boardArr, true);
-    
-    std::vector<BoardMove> validMoves;
-    std::vector<BoardMove> expectedValidMoves;
-    for (int rank = 6; rank >= 1; rank--) {
-        expectedValidMoves.push_back(BoardMove(BoardSquare(7, A), BoardSquare(rank, A)));
-        expectedValidMoves.push_back(BoardMove(BoardSquare(7, B), BoardSquare(rank, B)));
-    }
-    for (int file = H; file >= C; file--) {
-        expectedValidMoves.push_back(BoardMove(BoardSquare(7, B), BoardSquare(7, file)));
-    }
-    uint64_t whiteRooks = arrayToBitboardPieceType(boardArr, WRook);
-    validRookMoves(board, validMoves, whiteRooks);
-
-    std::sort(validMoves.begin(), validMoves.end());
-    std::sort(expectedValidMoves.begin(), expectedValidMoves.end());
-    ASSERT_EQ(validMoves, expectedValidMoves);
+    Board board("BB5k/8/8/8/8/8/2K5/RR5r w - - 0 1");
+    std::vector<BoardMove> moves = MoveGen::moveGenerator(board);
+    ASSERT_EQ(moves.size(), 37);
 }
 
 TEST_F(MoveGenTest, validBishopMoves1) {
-    std::array<pieceTypes, BOARD_SIZE> boardArr = {
-        EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece,
-        EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece,
-        EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, BBishop   , EmptyPiece, EmptyPiece,
-        EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece,
-        EmptyPiece, EmptyPiece, EmptyPiece, WBishop   , EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece,
-        EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece,
-        EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece,
-        WBishop   , WKing     , EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece,
-    };
-    Board board(boardArr);
-    
-    std::vector<BoardMove> validMoves;
-    std::vector<BoardMove> expectedValidMoves = {
-        BoardMove(BoardSquare(7, A), BoardSquare(6, B)),
-        BoardMove(BoardSquare(7, A), BoardSquare(5, C)),
-
-        BoardMove(BoardSquare(4, D), BoardSquare(5, C)),
-        BoardMove(BoardSquare(4, D), BoardSquare(6, B)),
-
-        BoardMove(BoardSquare(4, D), BoardSquare(3, C)),
-        BoardMove(BoardSquare(4, D), BoardSquare(2, B)),
-        BoardMove(BoardSquare(4, D), BoardSquare(1, A)),
-
-        BoardMove(BoardSquare(4, D), BoardSquare(5, E)),
-        BoardMove(BoardSquare(4, D), BoardSquare(6, F)),
-        BoardMove(BoardSquare(4, D), BoardSquare(7, G)),
-
-        BoardMove(BoardSquare(4, D), BoardSquare(3, E)),
-        BoardMove(BoardSquare(4, D), BoardSquare(2, F)),
-    };
-    uint64_t whiteBishops = arrayToBitboardPieceType(boardArr, WBishop);
-    validBishopMoves(board, validMoves, whiteBishops);
-
-    std::sort(validMoves.begin(), validMoves.end());
-    std::sort(expectedValidMoves.begin(), expectedValidMoves.end());
-    ASSERT_EQ(validMoves, expectedValidMoves);
+    Board board("7k/8/5b2/8/3B4/8/8/BK6 w - - 0 1");
+    std::vector<BoardMove> moves = MoveGen::moveGenerator(board);
+    ASSERT_EQ(moves.size(), 16);
 }
 
 TEST_F(MoveGenTest, validQueenMoves1) {
-    std::array<pieceTypes, BOARD_SIZE> boardArr = {
-        EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece,
-        EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece,
-        EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece,
-        EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece,
-        EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece,
-        EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece,
-        EmptyPiece, EmptyPiece, WKing     , EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece,
-        WQueen    , EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, WQueen    ,
-    };
-    Board board(boardArr);
-    
-    std::vector<BoardMove> validMoves;
-    std::vector<BoardMove> expectedValidMoves;
-    for (int i = 1; i <= 7; i++) {
-        expectedValidMoves.push_back(BoardMove(BoardSquare(7, A), BoardSquare(7 - i, A)));
-        expectedValidMoves.push_back(BoardMove(BoardSquare(7, A), BoardSquare(7 - i, A + i)));
-
-        expectedValidMoves.push_back(BoardMove(BoardSquare(7, H), BoardSquare(7 - i, H)));
-        expectedValidMoves.push_back(BoardMove(BoardSquare(7, H), BoardSquare(7 - i, H - i)));
-    }
-    for (int i = 1; i <= 6; i++) {
-        expectedValidMoves.push_back(BoardMove(BoardSquare(7, A), BoardSquare(7, A + i)));
-        expectedValidMoves.push_back(BoardMove(BoardSquare(7, H), BoardSquare(7, H - i)));
-    }
-    uint64_t whiteQueens = arrayToBitboardPieceType(boardArr, WQueen);
-    validQueenMoves(board, validMoves, whiteQueens);
-
-    std::sort(validMoves.begin(), validMoves.end());
-    std::sort(expectedValidMoves.begin(), expectedValidMoves.end());
-    ASSERT_EQ(validMoves, expectedValidMoves);
+    Board board("3k4/8/8/8/8/8/2K5/Q6Q w - - 0 1");
+    std::vector<BoardMove> moves = MoveGen::moveGenerator(board);
+    ASSERT_EQ(moves.size(), 48);
 }
 
 TEST_F(MoveGenTest, validKingMovesNoCastle) {
-    std::array<pieceTypes, BOARD_SIZE> boardArr = {
-        EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece,
-        EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece,
-        EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece,
-        EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece,
-        EmptyPiece, EmptyPiece, EmptyPiece, WKing     , EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece,
-        EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, BPawn     , EmptyPiece, EmptyPiece, EmptyPiece,
-        EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece,
-        WKing     , EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece,
-    };
-    Board board(boardArr);
-    board.castlingRights = noCastle;
-    
-    std::vector<BoardMove> validMoves;
-    std::vector<BoardMove> expectedValidMoves = {
-        BoardMove(BoardSquare(7, A), BoardSquare(6, A)),
-        BoardMove(BoardSquare(7, A), BoardSquare(6, B)),
-        BoardMove(BoardSquare(7, A), BoardSquare(7, B)),
-
-        BoardMove(BoardSquare(4, D), BoardSquare(3, E)),
-        BoardMove(BoardSquare(4, D), BoardSquare(3, D)),
-        BoardMove(BoardSquare(4, D), BoardSquare(3, C)),
-        BoardMove(BoardSquare(4, D), BoardSquare(5, E)),
-        BoardMove(BoardSquare(4, D), BoardSquare(5, D)),
-        BoardMove(BoardSquare(4, D), BoardSquare(5, C)),
-        BoardMove(BoardSquare(4, D), BoardSquare(4, E)),
-        BoardMove(BoardSquare(4, D), BoardSquare(4, C)),
-    };
-    uint64_t whiteKings = arrayToBitboardPieceType(boardArr, WKing);
-    validKingMoves(board, validMoves, whiteKings);
-
-    std::sort(validMoves.begin(), validMoves.end());
-    std::sort(expectedValidMoves.begin(), expectedValidMoves.end());
-    ASSERT_EQ(validMoves, expectedValidMoves);
+    Board board("7k/8/8/8/8/4p3/8/4K3 w - - 0 1");
+    std::vector<BoardMove> moves = MoveGen::moveGenerator(board);
+    ASSERT_EQ(moves.size(), 3);
 }
 
 TEST_F(MoveGenTest, validKingMovesKingCastle) {
-    std::array<pieceTypes, BOARD_SIZE> boardArr = {
-        EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece,
-        EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece,
-        EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece,
-        EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece,
-        EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece,
-        EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece,
-        EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece,
-        WRook     , EmptyPiece, WBishop   , EmptyPiece, WKing     , EmptyPiece, EmptyPiece, WRook     ,
-    };
-    Board board(boardArr);
-    
-    std::vector<BoardMove> validMoves;
-    std::vector<BoardMove> expectedValidMoves = {
-        BoardMove(BoardSquare(7, E), BoardSquare(6, D)),
-        BoardMove(BoardSquare(7, E), BoardSquare(6, E)),
-        BoardMove(BoardSquare(7, E), BoardSquare(6, F)),
-        BoardMove(BoardSquare(7, E), BoardSquare(7, D)),
-        BoardMove(BoardSquare(7, E), BoardSquare(7, F)),
-
-        BoardMove(BoardSquare(7, E), BoardSquare(7, G)),
-    };
-    uint64_t whiteKings = arrayToBitboardPieceType(boardArr, WKing);
-    validKingMoves(board, validMoves, whiteKings);
-
-    std::sort(validMoves.begin(), validMoves.end());
-    std::sort(expectedValidMoves.begin(), expectedValidMoves.end());
-    ASSERT_EQ(validMoves, expectedValidMoves);    
+    Board board("4k3/8/8/8/8/8/8/R1B1K2R w KQ - 0 1");
+    std::vector<BoardMove> moves = MoveGen::moveGenerator(board);
+    ASSERT_EQ(moves.size(), 30);
 }
 
 TEST_F(MoveGenTest, validKingMovesQueenCastle) {
-    std::array<pieceTypes, BOARD_SIZE> boardArr = {
-        EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece,
-        EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece,
-        EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece,
-        EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece,
-        EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece,
-        EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece,
-        EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece,
-        WRook     , EmptyPiece, EmptyPiece, EmptyPiece, WKing     , EmptyPiece, WBishop   , WRook     ,
-    };
-    Board board(boardArr);
-    
-    std::vector<BoardMove> validMoves;
-    std::vector<BoardMove> expectedValidMoves = {
-        BoardMove(BoardSquare(7, E), BoardSquare(6, D)),
-        BoardMove(BoardSquare(7, E), BoardSquare(6, E)),
-        BoardMove(BoardSquare(7, E), BoardSquare(6, F)),
-        BoardMove(BoardSquare(7, E), BoardSquare(7, D)),
-        BoardMove(BoardSquare(7, E), BoardSquare(7, F)),
-
-        BoardMove(BoardSquare(7, E), BoardSquare(7, C)),
-    };
-    uint64_t whiteKings = arrayToBitboardPieceType(boardArr, WKing);
-    validKingMoves(board, validMoves, whiteKings);
-
-    std::sort(validMoves.begin(), validMoves.end());
-    std::sort(expectedValidMoves.begin(), expectedValidMoves.end());
-    ASSERT_EQ(validMoves, expectedValidMoves);    
+    Board board("4k3/8/8/8/8/8/8/R3K1BR w KQ - 0 1");
+    std::vector<BoardMove> moves = MoveGen::moveGenerator(board);
+    ASSERT_EQ(moves.size(), 30);
 }
 
 TEST_F(MoveGenTest, validKingMovesInvalidCastle) {
-    std::array<pieceTypes, BOARD_SIZE> boardArr = {
-        EmptyPiece, EmptyPiece, EmptyPiece, BQueen    , EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece,
-        EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece,
-        EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece,
-        EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece,
-        EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece,
-        EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece,
-        EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece, EmptyPiece,
-        WRook     , EmptyPiece, EmptyPiece, EmptyPiece, WKing     , EmptyPiece, WBishop   , WRook     ,
-    };
-    Board board(boardArr);
-    
-    std::vector<BoardMove> validMoves;
-    std::vector<BoardMove> expectedValidMoves = {
-        BoardMove(BoardSquare(7, E), BoardSquare(6, E)),
-        BoardMove(BoardSquare(7, E), BoardSquare(6, F)),
-        BoardMove(BoardSquare(7, E), BoardSquare(7, F)),
-    };
-    uint64_t whiteKings = arrayToBitboardPieceType(boardArr, WKing);
-    validKingMoves(board, validMoves, whiteKings);
-
-    std::sort(validMoves.begin(), validMoves.end());
-    std::sort(expectedValidMoves.begin(), expectedValidMoves.end());
-    ASSERT_EQ(validMoves, expectedValidMoves);    
+    Board board("3qk3/8/8/8/8/8/8/R3K1BR w KQkq - 0 1");
+    std::vector<BoardMove> moves = MoveGen::moveGenerator(board);
+    ASSERT_EQ(moves.size(), 27);
 }
 
 TEST_F(MoveGenTest, moveGeneratorDefault) {


### PR DESCRIPTION
There are already magic bitboards for rooks and bishops, but this patch extends having attack tables for all pieces, which helps with move generation speed. 

```
Advancement Test:
Time Control: 10s + 0.1s
WDL: +480 =302 -387

Alpha: 0.05
Beta: 0.05
Elo0: 0
Elo1: 10

Lower bound: -2.94
Current LLR: 2.96
Upper bound: 2.94
```
