### PR TITLE
Transposition Table

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,6 +19,7 @@ target_sources(Blocky PRIVATE
     src/moveGen.cpp
     src/movePicker.cpp
     src/search.cpp
+    src/ttable.cpp
     src/eval.cpp
     src/timeman.cpp
     src/uci.cpp

--- a/src/move.cpp
+++ b/src/move.cpp
@@ -139,6 +139,10 @@ bool operator==(const BoardMove& lhs, const BoardMove& rhs) {
     return (lhs.pos1 == rhs.pos1) && (lhs.pos2 == rhs.pos2) && (lhs.promotionPiece == rhs.promotionPiece);
 }
 
+bool operator!=(const BoardMove& lhs, const BoardMove& rhs) {
+    return !(lhs == rhs);
+}
+
 bool operator<(const BoardMove& lhs, const BoardMove& rhs) {
     if (lhs.pos1 != rhs.pos1) {
         return lhs.pos1 < rhs.pos1;

--- a/src/move.hpp
+++ b/src/move.hpp
@@ -34,5 +34,6 @@ struct BoardMove {
 
     friend std::ostream& operator<<(std::ostream& os, const BoardMove& target);
     friend bool operator==(const BoardMove& lhs, const BoardMove& rhs);
+    friend bool operator!=(const BoardMove& lhs, const BoardMove& rhs);
     friend bool operator<(const BoardMove& lhs, const BoardMove& rhs);
 };

--- a/src/movePicker.cpp
+++ b/src/movePicker.cpp
@@ -1,4 +1,5 @@
 #include <vector>
+#include <iostream>
 
 #include "movePicker.hpp"
 #include "board.hpp"
@@ -14,17 +15,17 @@ MovePicker::MovePicker(std::vector<BoardMove>&& a_moves) {
 
 // Searching moves that are likely to be better helps with pruning in search. This is move ordering.
 // More promising moves are given higher scores and then searched first.
-void MovePicker::assignMoveScores(const Board& board) {
+void MovePicker::assignMoveScores(const Board& board, BoardMove PVNode) {
     size_t i = 0;
     for (BoardMove move: this->moves) {
-        // capture
-        // moveGen outputs least valuable piece moves first, so least value captures is automatic 
-        if (board.getPiece(move.pos2) != EmptyPiece) {
-            this->moveScores[i] = 1;
+        if (move == PVNode) {
+            this->moveScores[i] = MoveScores::PVNode;
         }
-        // default
+        else if (board.getPiece(move.pos2) != EmptyPiece) {
+            this->moveScores[i] = MoveScores::Capture;
+        }
         else {
-            this->moveScores[i] = 0;
+            this->moveScores[i] = MoveScores::Quiet;
         }
         i++;
     }

--- a/src/movePicker.hpp
+++ b/src/movePicker.hpp
@@ -6,10 +6,16 @@
 #include "move.hpp"
 #include "types.hpp"
 
+enum MoveScores {
+    PVNode = 10000,
+    Capture = 100,
+    Quiet = 0,
+};
+
 class MovePicker {
     public:
         MovePicker(std::vector<BoardMove>&& a_moves); 
-        void assignMoveScores(const Board& board);
+        void assignMoveScores(const Board& board, BoardMove PVNode = BoardMove());
         bool movesLeft() const;
         BoardMove pickMove();
     

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -166,11 +166,13 @@ namespace Search {
     void Searcher::storeInTT(TTable::Entry entry, Node result, int distanceFromRoot) {
         int posIndex = TTable::table.getIndex(this->board.zobristKey);
         // only overwrite with certain conditions
-        if (distanceFromRoot >= entry.depth && result.move != BoardMove()) {
-            entry.key = static_cast<uint16_t>(this->board.zobristKey);
-            entry.depth = distanceFromRoot;
-            entry.move = result.move;
-            TTable::table.storeEntry(posIndex, entry);
+        if ( (distanceFromRoot >= entry.depth || this->board.fiftyMoveRule >= entry.age)
+            && result.move != BoardMove()) {
+                entry.key = static_cast<uint16_t>(this->board.zobristKey);
+                entry.age = this->board.fiftyMoveRule;
+                entry.depth = distanceFromRoot;
+                entry.move = result.move;
+                TTable::table.storeEntry(posIndex, entry);
         }
     }
 

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -26,11 +26,8 @@ namespace Search {
                 result.depth = this->max_depth;
                 result.eval = root.eval;
                 // compute mate-in
-                if (result.eval > MAX_BETA - 100) {
-                    result.mateIn = MAX_BETA - result.eval;
-                }
-                if (result.eval < MIN_ALPHA + 100) {
-                    result.mateIn = result.eval - MIN_ALPHA;
+                if (abs(result.eval) > MAX_BETA - 100) {
+                    result.mateIn = MAX_BETA - abs(result.eval);
                 }
                 this->outputUciInfo(result);
             }
@@ -192,7 +189,7 @@ namespace Search {
         if (searchResult.mateIn == Search::NO_MATE) {
             std::cout << "score cp " << searchResult.eval << ' ';
         } else { 
-            std::cout << "mate " << (searchResult.mateIn + 1) / 2 << ' '; // convert plies to moves
+            std::cout << "score mate " << (searchResult.mateIn + 1) / 2 << ' '; // convert plies to moves
         }
         std::cout << std::endl;
 

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -200,6 +200,7 @@ namespace Search {
         } else { 
             std::cout << "score mate " << (searchResult.mateIn + 1) / 2 << ' '; // convert plies to moves
         }
+        std::cout << "hashfull " << TTable::table.hashFull() << ' ';
         std::cout << std::endl;
 
     }

--- a/src/search.hpp
+++ b/src/search.hpp
@@ -6,6 +6,7 @@
 
 #include "board.hpp"
 #include "eval.hpp"
+#include "ttable.hpp"
 #include "timeman.hpp"
 
 namespace Search {
@@ -42,6 +43,7 @@ namespace Search {
             Info startThinking();
             Node search(int alpha, int beta, int depthLeft, int distanceFromRoot);
             int quiesce(int alpha, int beta, int depthLeft);
+            void storeInTT(TTable::Entry entry, Node result, int distanceFromRoot);
 
             void outputUciInfo(Info searchResult);
         private:

--- a/src/ttable.cpp
+++ b/src/ttable.cpp
@@ -1,0 +1,38 @@
+#include <cstdint>
+#include <vector>
+
+#include "ttable.hpp"
+#include "move.hpp"
+
+namespace TTable {
+
+// global definition
+TTable table = TTable();
+
+void TTable::resize(int sizeMb) {
+    // sizeof uses bytes and not megabytes
+    int numElements = sizeMb * 1024 * 1024 / sizeof(Entry);
+    this->table.resize(numElements);
+}
+
+void TTable::clear() {
+    std::fill(this->table.begin(), this->table.end(), Entry());
+}
+
+bool TTable::entryExists(int index) {
+    return this->table[index].key != 0;
+}
+
+Entry TTable::getEntry(int index) {
+    return this->table[index];
+}
+
+void TTable::storeEntry(int key, Entry entry){
+    this->table[key] = entry;
+}
+
+int TTable::getIndex(uint64_t key) {
+    return key % this->size;
+}
+
+} // namespace TTable

--- a/src/ttable.cpp
+++ b/src/ttable.cpp
@@ -21,6 +21,17 @@ void TTable::clear() {
     std::fill(this->table.begin(), this->table.end(), Entry());
 }
 
+// estimates how much the table is full in tenths of percents
+int TTable::hashFull() {
+    int entriesUsed = 0;
+    for (int i = 0; i < 1000; ++i) {
+        if (this->table[i].move != BoardMove()) {
+            ++entriesUsed;
+        }
+    }
+    return entriesUsed;
+}
+
 bool TTable::entryExists(uint64_t key) const {
     int index = this->getIndex(key);
     return static_cast<uint16_t>(key) == this->table[index].key;

--- a/src/ttable.cpp
+++ b/src/ttable.cpp
@@ -1,6 +1,8 @@
 #include <cstdint>
+#include <iostream>
 #include <vector>
 
+#include "bitboard.hpp"
 #include "ttable.hpp"
 #include "move.hpp"
 
@@ -11,27 +13,28 @@ TTable table = TTable();
 
 void TTable::resize(int sizeMb) {
     // sizeof uses bytes and not megabytes
-    int numElements = sizeMb * 1024 * 1024 / sizeof(Entry);
-    this->table.resize(numElements);
+    this->size = sizeMb * 1024 * 1024 / sizeof(Entry);
+    this->table.resize(this->size);
 }
 
 void TTable::clear() {
     std::fill(this->table.begin(), this->table.end(), Entry());
 }
 
-bool TTable::entryExists(int index) {
-    return this->table[index].key != 0;
+bool TTable::entryExists(uint64_t key) const {
+    int index = this->getIndex(key);
+    return static_cast<uint16_t>(key) == this->table[index].key;
 }
 
-Entry TTable::getEntry(int index) {
+Entry TTable::getEntry(int index) const {
     return this->table[index];
 }
 
-void TTable::storeEntry(int key, Entry entry){
-    this->table[key] = entry;
+void TTable::storeEntry(int index, Entry entry) {
+    this->table[index] = entry;
 }
 
-int TTable::getIndex(uint64_t key) {
+int TTable::getIndex(uint64_t key) const {
     return key % this->size;
 }
 

--- a/src/ttable.hpp
+++ b/src/ttable.hpp
@@ -11,6 +11,7 @@ constexpr int DEFAULT_SIZEMB = 128;
 
 struct Entry {
     uint16_t key = 0;
+    uint8_t age = 0;
     int depth = 0;
     BoardMove move = BoardMove();
 };

--- a/src/ttable.hpp
+++ b/src/ttable.hpp
@@ -1,0 +1,37 @@
+#pragma once
+
+#include <cstdint>
+#include <vector>
+
+#include "move.hpp"
+
+namespace TTable {
+
+constexpr uint64_t KEY_MASK = 0xFFFFull;
+constexpr int DEFAULT_SIZEMB = 128;
+
+struct Entry {
+    uint16_t key = 0;
+    int depth = 0;
+    BoardMove move = BoardMove();
+};
+
+class TTable {
+    public:
+        void resize(int sizeMb);
+        TTable() {this->resize(DEFAULT_SIZEMB);};
+        void clear();
+
+        bool entryExists(int index);
+        Entry getEntry(int index);
+        void storeEntry(int index, Entry entry);
+        int getIndex(uint64_t key);
+    private:
+        std::vector<Entry> table;
+        int size;
+};
+
+// global declaration
+extern TTable table;
+
+} // namespace TTable

--- a/src/ttable.hpp
+++ b/src/ttable.hpp
@@ -21,6 +21,7 @@ class TTable {
         void resize(int sizeMb);
         TTable() {this->resize(DEFAULT_SIZEMB);};
         void clear();
+        int hashFull();
 
         int getIndex(uint64_t key) const;
         bool entryExists(uint64_t key) const;

--- a/src/ttable.hpp
+++ b/src/ttable.hpp
@@ -7,7 +7,6 @@
 
 namespace TTable {
 
-constexpr uint64_t KEY_MASK = 0xFFFFull;
 constexpr int DEFAULT_SIZEMB = 128;
 
 struct Entry {
@@ -22,12 +21,12 @@ class TTable {
         TTable() {this->resize(DEFAULT_SIZEMB);};
         void clear();
 
-        bool entryExists(int index);
-        Entry getEntry(int index);
+        int getIndex(uint64_t key) const;
+        bool entryExists(uint64_t key) const;
+        Entry getEntry(int index) const;
         void storeEntry(int index, Entry entry);
-        int getIndex(uint64_t key);
-    private:
         std::vector<Entry> table;
+    private:
         int size;
 };
 

--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -1,11 +1,13 @@
+#include <cctype>
+#include <chrono>
 #include <iostream>
 #include <string>
 #include <sstream>
 #include <stdexcept>
-#include <chrono>
 
 #include "uci.hpp"
 #include "timeman.hpp"
+#include "ttable.hpp"
 #include "search.hpp"
 #include "moveGen.hpp"
 #include "board.hpp"
@@ -24,6 +26,7 @@ namespace Uci {
         std::cout << "id author BlockyTeam\n";
 
         std::cout << "option name maxDepth type spin default 100 min 1 max 200\n";
+        std::cout << "option name Hash type spin default 128 min 128 max 1024\n";
 
         std::cout << "uciok\n";
         return true;
@@ -42,18 +45,25 @@ namespace Uci {
     }
 
     void setOption(std::istringstream& input){ 
-        std::string token;
-        input >> token; 
-        if (token != "name") {return;}
-        input >> token;
-        if (token == "maxDepth") {
-            input >> token;
-            input >> token;
-            OPTIONS.depth = std::stoi(token);
-            std::cout << "Depth set to: " << OPTIONS.depth << std::endl;
-        };
-    }
+        // Example: setoption name maxDepth value 2
 
+        // gather inputs
+        std::string token, id, value;
+        input >> token; // name qualifier
+        input >> id;
+        input >> token; // value qualifier
+        input >> value;
+
+        // uci requires id to not be case sensitive
+        std::transform(id.begin(), id.end(), id.begin(), ::tolower);
+
+        if (id == "maxdepth") {
+            OPTIONS.depth = std::stoi(value);
+        }
+        else if (id == "hash") {
+            TTable::table.resize(std::stoi(value));
+        }
+    }
 
     void uciLoop() {
         std::string commandLine, commandToken;
@@ -63,7 +73,7 @@ namespace Uci {
             std::istringstream commandStream(commandLine);
             commandStream >> commandToken;
 
-            if (commandToken == "ucinewgame") {}
+            if (commandToken == "ucinewgame") {TTable::table.clear();}
             else if (commandToken == "position") {currBoard = position(commandStream);}
             else if (commandToken == "go") {Uci::go(commandStream, currBoard);}
             else if (commandToken == "isready") {isready();}
@@ -120,6 +130,7 @@ namespace Uci {
         Search::Searcher currSearch(board, allytime, OPTIONS.depth);
         Search::Info result = currSearch.startThinking();
         std::cout << "bestmove " << result.move.toStr() << "\n";
+        TTable::table.clear();
     }
 
     void isready() {

--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -130,7 +130,6 @@ namespace Uci {
         Search::Searcher currSearch(board, allytime, OPTIONS.depth);
         Search::Info result = currSearch.startThinking();
         std::cout << "bestmove " << result.move.toStr() << "\n";
-        TTable::table.clear();
     }
 
     void isready() {

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -25,6 +25,7 @@ add_executable(allTests
     ../src/moveGen.cpp
     ../src/movePicker.cpp
     ../src/timeman.cpp
+    ../src/ttable.cpp
     ../src/search.cpp
     ../src/eval.cpp
 )


### PR DESCRIPTION
Transposition tables help with move ordering between iterative deepening, and incomplete searches can now be used for final moves given that only better moves in incomplete searches overwrite the best move in the previous search.

```
Advancement Test:
Time Control: 10s + 0.1s
Games: +331 =106 -235
Elo: 50.0 +/- 24.3

Alpha: 0.05
Beta: 0.05
Elo0: 0
Elo1: 10
H1 was accepted
```
