### PR TITLE
Fix mate score reporting for losing side + report seldepth

### DIFF
--- a/src/search.hpp
+++ b/src/search.hpp
@@ -10,15 +10,15 @@
 #include "timeman.hpp"
 
 namespace Search {
-    const int MIN_ALPHA = -1000000;
-    const int MAX_BETA = 1000000;
-    const int NO_MATE = -1;
-    const int TIME_LIMIT_TEST = 1000000; //time in microseconds
+    constexpr int MIN_ALPHA = -1000000;
+    constexpr int MAX_BETA = 1000000;
+    constexpr int NO_MATE = -1000000;
 
     // used for outside UCI representation    
     struct Info {
         uint64_t nodes = 0;
         int depth = 0;
+        int seldepth = 0;
         int eval = 0;
         int mateIn = NO_MATE;
         BoardMove move;
@@ -37,19 +37,20 @@ namespace Search {
                 this->board = a_board;
                 this->nodes = 0;
                 this->max_depth = 0;
+                this->max_seldepth = 0;
                 this->tm = Timeman::TimeManager(ms);
                 this->depth_limit = depthLimit;
             };
             Info startThinking();
             Node search(int alpha, int beta, int depthLeft, int distanceFromRoot);
-            int quiesce(int alpha, int beta, int depthLeft);
+            int quiesce(int alpha, int beta, int depthLeft, int distanceFromRoot);
             void storeInTT(TTable::Entry entry, Node result, int distanceFromRoot);
 
             void outputUciInfo(Info searchResult);
         private:
             Board board;
             uint64_t nodes;
-            int max_depth;
+            int max_depth, max_seldepth;
             Timeman::TimeManager tm;
             int depth_limit;
     };


### PR DESCRIPTION
Mates would report positive scores irrespective of the losing side. Seldepth basically includes quiescence for now. I stopped the SPRT early for now, but it would've been merged even if regression.

```
Regression Test:
Time Control: 10s + 0.1s
Games: N=2423 W=1023 L=1038 D=362
Elo: -2.2 +/- 12.7

Alpha: 0.05
Beta: 0.05
Elo0: 0
Elo1: 10
No result
```
