### PR TITLE
Use 64 bit keys for TTable

### DIFF
--- a/src/board.cpp
+++ b/src/board.cpp
@@ -272,6 +272,7 @@ void Board::makeMove(BoardSquare pos1, BoardSquare pos2, pieceTypes promotionPie
     // after finalizing move logic, now switch turns
     this->isWhiteTurn = !this->isWhiteTurn; 
     this->zobristKey ^= Zobrist::isBlackKey;
+    this->age++;
 
     // update history to include curr key
     this->zobristKeyHistory.push_back(this->zobristKey);
@@ -312,6 +313,7 @@ void Board::undoMove() {
     this->castlingRights = prev.castlingRights;
     this->enPassSquare = prev.enPassSquare;
     this->fiftyMoveRule = prev.fiftyMoveRule;
+    this->age--;
     this->materialDifference = prev.materialDifference;
     this->eval = prev.eval;
 

--- a/src/board.hpp
+++ b/src/board.hpp
@@ -54,6 +54,7 @@ struct Board {
     bool isWhiteTurn;
     castleRights castlingRights; // bitwise castling rights tracker
     int fiftyMoveRule;
+    int age = 0;
     BoardSquare enPassSquare; // en passant square
     int materialDifference; // updates on capture or promotion, so the eval doesn't have to calculate for each board, positive is white advantage
                             // Possibly could be combined with attributes

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -130,7 +130,7 @@ int Searcher::search(int alpha, int beta, int depth, int distanceFromRoot) {
         }
     }
     // A search for this depth is complete with a best move, so it can be stored in the transposition table
-    this->storeInTT(entry, bestMove, distanceFromRoot);
+    this->storeInTT(entry, bestMove, depth);
     return score;
 }
 
@@ -172,7 +172,7 @@ int Searcher::quiesce(int alpha, int beta, int depth, int distanceFromRoot) {
 
 }
 
-void Searcher::storeInTT(TTable::Entry entry, BoardMove move, int distanceFromRoot) {
+void Searcher::storeInTT(TTable::Entry entry, BoardMove move, int depth) {
     int posIndex = TTable::table.getIndex(this->board.zobristKey);
     /* entries in the transposition table are overwritten under two conditions:
     1. The current search depth is greater than the entry's depth, meaning that a better
@@ -181,11 +181,11 @@ void Searcher::storeInTT(TTable::Entry entry, BoardMove move, int distanceFromRo
     in hash are preserved in the table since there can be repeated boards, but replacing entries
     with moves from more modern roots is better
     */
-    if ( (distanceFromRoot >= entry.depth || this->board.fiftyMoveRule >= entry.age) 
+    if ( (depth >= entry.depth || this->board.fiftyMoveRule >= entry.age) 
         && move != BoardMove()) {
             entry.key = static_cast<uint16_t>(this->board.zobristKey);
             entry.age = this->board.fiftyMoveRule;
-            entry.depth = distanceFromRoot;
+            entry.depth = depth;
             entry.move = move;
             TTable::table.storeEntry(posIndex, entry);
     }

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -183,7 +183,7 @@ void Searcher::storeInTT(TTable::Entry entry, BoardMove move, int depth) {
     */
     if ( (depth >= entry.depth || this->board.fiftyMoveRule >= entry.age) 
         && move != BoardMove()) {
-            entry.key = static_cast<uint16_t>(this->board.zobristKey);
+            entry.key = this->board.zobristKey;
             entry.age = this->board.fiftyMoveRule;
             entry.depth = depth;
             entry.move = move;

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -181,10 +181,10 @@ void Searcher::storeInTT(TTable::Entry entry, BoardMove move, int depth) {
     in hash are preserved in the table since there can be repeated boards, but replacing entries
     with moves from more modern roots is better
     */
-    if ( (depth >= entry.depth || this->board.fiftyMoveRule >= entry.age) 
+    if ( (depth >= entry.depth || this->board.age >= entry.age)
         && move != BoardMove()) {
             entry.key = this->board.zobristKey;
-            entry.age = this->board.fiftyMoveRule;
+            entry.age = this->board.age;
             entry.depth = depth;
             entry.move = move;
             TTable::table.storeEntry(posIndex, entry);

--- a/src/search.hpp
+++ b/src/search.hpp
@@ -38,7 +38,7 @@ class Searcher {
         template <NodeTypes NODE>
         int search(int alpha, int beta, int depth, int distanceFromRoot);
         int quiesce(int alpha, int beta, int depth, int distanceFromRoot);
-        void storeInTT(TTable::Entry entry, BoardMove move, int distanceFromRoot);
+        void storeInTT(TTable::Entry entry, BoardMove move, int depth);
 
         void outputUciInfo(Info searchResult);
         void setPrintInfo(bool flag) {this->printInfo = flag;}; 

--- a/src/ttable.cpp
+++ b/src/ttable.cpp
@@ -34,7 +34,7 @@ int TTable::hashFull() {
 
 bool TTable::entryExists(uint64_t key) const {
     int index = this->getIndex(key);
-    return static_cast<uint16_t>(key) == this->table[index].key;
+    return key == this->table[index].key;
 }
 
 Entry TTable::getEntry(int index) const {

--- a/src/ttable.hpp
+++ b/src/ttable.hpp
@@ -10,7 +10,7 @@ namespace TTable {
 constexpr int DEFAULT_SIZEMB = 128;
 
 struct Entry {
-    uint16_t key = 0;
+    uint64_t key = 0;
     uint8_t age = 0;
     int depth = 0;
     BoardMove move = BoardMove();


### PR DESCRIPTION
There's also some changes to age and depth that doesn't affect the bench like the key size changes did. Those are done to make the code make more sense.

```
Advancement Test:
Time Control: 10s + 0.1s
Games: N=482 W=244 L=153 D=85
Elo: 66.4 +/- 28.6
Bench: 26355345

Alpha: 0.05
Beta: 0.05
Elo0: 0
Elo1: 10
H1 was accepted
```
