### PR TITLE
softTimeUp + account for increment

### DIFF
--- a/src/bench.cpp
+++ b/src/bench.cpp
@@ -19,7 +19,8 @@ uint64_t start() {
     for (int i = 0; i < numPositions; ++i) {
         auto fen = fens[i];
         std::cout << "Searching position " << (i + 1) << '/' << numPositions << ": " << fen << '\n';
-        Search::Searcher engine(Board(fen), Timeman::INF_TIME, BENCHDEPTH);
+        Timeman::TimeManager tm;
+        Search::Searcher engine(Board(fen), tm, BENCHDEPTH);
         engine.setPrintInfo(false);
         nodeCount += engine.startThinking().nodes;
     }

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -30,7 +30,7 @@ Info Searcher::startThinking() {
         }
 
         // only update eval for completed searches
-        if (!tm.timeUp()) {
+        if (!tm.hardTimeUp()) {
             result.eval = score;
         }
 
@@ -45,7 +45,8 @@ Info Searcher::startThinking() {
             this->outputUciInfo(result);
         }
         
-        if (this->tm.timeUp()) {
+        // only break out of search early for optimistic time used
+        if (this->tm.softTimeUp()) {
             break;
         }
     }
@@ -58,7 +59,7 @@ int Searcher::search(int alpha, int beta, int depth, int distanceFromRoot) {
 
     // time up
     int score = 0;
-    if(this->tm.timeUp()) {
+    if(this->tm.hardTimeUp()) {
         return score;
     }
 
@@ -113,7 +114,7 @@ int Searcher::search(int alpha, int beta, int depth, int distanceFromRoot) {
         board.undoMove(); 
 
         // don't update best move if time is up
-        if (this->tm.timeUp()) {
+        if (this->tm.hardTimeUp()) {
             return score;
         }
         
@@ -140,7 +141,7 @@ int Searcher::search(int alpha, int beta, int depth, int distanceFromRoot) {
 }
 
 int Searcher::quiesce(int alpha, int beta, int depth, int distanceFromRoot) {
-    if(this->tm.timeUp()) {
+    if(this->tm.hardTimeUp()) {
         return 0;
     }
 

--- a/src/search.hpp
+++ b/src/search.hpp
@@ -26,11 +26,11 @@ struct Info {
 
 class Searcher {
     public:  
-        Searcher(Board a_board, int ms, int depthLimit) {
+        Searcher(Board a_board, Timeman::TimeManager a_tm, int depthLimit) {
             this->board = a_board;
             this->nodes = 0;
             this->max_seldepth = 0;
-            this->tm = Timeman::TimeManager(ms);
+            this->tm = a_tm;
             this->depth_limit = depthLimit;
         };
         Info startThinking();

--- a/src/timeman.cpp
+++ b/src/timeman.cpp
@@ -5,14 +5,21 @@
 
 namespace Timeman {
 
-bool TimeManager::timeUp() const {
-    auto currTime = std::chrono::high_resolution_clock::now();
-    return std::chrono::duration_cast<std::chrono::microseconds>(currTime - startTime).count() > timeLimit;
+using namespace std::chrono;
+
+bool TimeManager::hardTimeUp() const {
+    auto currTime = high_resolution_clock::now();
+    return duration_cast<microseconds>(currTime - startTime).count() > hardTimeLimit;
+}
+
+bool TimeManager::softTimeUp() const {
+    auto currTime = high_resolution_clock::now();
+    return duration_cast<microseconds>(currTime - startTime).count() > softTimeLimit;
 }
 
 int64_t TimeManager::getTimeElapsed() const {
-    auto currTime = std::chrono::high_resolution_clock::now();
-    return std::chrono::duration_cast<std::chrono::milliseconds>(currTime - startTime).count();
+    auto currTime = high_resolution_clock::now();
+    return duration_cast<milliseconds>(currTime - startTime).count();
 }
 
 } // namespace Timeman

--- a/src/timeman.hpp
+++ b/src/timeman.hpp
@@ -9,7 +9,7 @@ constexpr uint64_t INF_TIME = 1 << 28;
 
 struct TimeManager
 {
-    TimeManager(int time = INF_TIME, int inc = 0) {
+    TimeManager(uint64_t time = INF_TIME, uint64_t inc = 0) {
         // convert into microseconds
         time *= 1000;
         inc *= 1000;

--- a/src/timeman.hpp
+++ b/src/timeman.hpp
@@ -11,14 +11,16 @@ struct TimeManager
 {
     TimeManager(int ms = INF_TIME) {
         this->startTime = std::chrono::high_resolution_clock::now();
-        this->timeLimit = ms * 1000 / 20;
+        this->hardTimeLimit = ms * 1000 / 20;
+        this->softTimeLimit = this->hardTimeLimit / 3;
     }
 
-    bool timeUp() const;
+    bool hardTimeUp() const;
+    bool softTimeUp() const;
     int64_t getTimeElapsed() const;
     
     std::chrono::system_clock::time_point startTime; 
-    int64_t timeLimit;
+    int64_t hardTimeLimit, softTimeLimit;
 };
 
 } // namespace Timeman

--- a/src/timeman.hpp
+++ b/src/timeman.hpp
@@ -9,10 +9,14 @@ constexpr uint64_t INF_TIME = 1 << 28;
 
 struct TimeManager
 {
-    TimeManager(int ms = INF_TIME) {
+    TimeManager(int time = INF_TIME, int inc = 0) {
+        // convert into microseconds
+        time *= 1000;
+        inc *= 1000;
+
         this->startTime = std::chrono::high_resolution_clock::now();
-        this->hardTimeLimit = ms * 1000 / 20;
-        this->softTimeLimit = this->hardTimeLimit / 3;
+        this->hardTimeLimit = time / 20 + inc / 2;
+        this->softTimeLimit = this->hardTimeLimit / 2;
     }
 
     bool hardTimeUp() const;

--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -122,16 +122,27 @@ Board position(std::istringstream& input) {
 
 void go(std::istringstream& input, Board& board) {
     std::string token;
-    int wtime = Timeman::INF_TIME, btime = Timeman::INF_TIME, allytime;
+
+    // initialize time parameters
+    int wtime, btime, winc, binc;
+    wtime = btime = Timeman::INF_TIME;
+    winc = binc = 0;
+
+    // input time parameters
     std::string param, value;
     while (input >> param) {
         input >> value;
         if (param == "wtime") {wtime = std::stoi(value);}
         else if (param == "btime") {btime = std::stoi(value);}
+        else if (param == "winc") {winc = std::stoi(value);}
+        else if (param == "binc") {binc = std::stoi(value);}
     }   
-    allytime = board.isWhiteTurn ? wtime : btime;
+    int allytime = board.isWhiteTurn ? wtime : btime;
+    int allyInc = board.isWhiteTurn ? winc : binc;
+    Timeman::TimeManager tm(allytime, allyInc);
 
-    Search::Searcher currSearch(board, allytime, OPTIONS.depth);
+    // begin search
+    Search::Searcher currSearch(board, tm, OPTIONS.depth);
     Search::Info result = currSearch.startThinking();
     std::cout << "bestmove " << result.move.toStr() << "\n";
 }


### PR DESCRIPTION
There are two main changes:
* Searches after an iterative deepening iteration can break when a soft time limit is up. This saves time not doing incompleted searches.
* Increment is accounted for.

```
Advancement Test:
Time Control: 10s + 0.1s
Games: N=1695 W=722 L=616 D=357
Elo: 21.8 +/- 14.7
Bench: 28577791 (No change)

Alpha: 0.05
Beta: 0.05
Elo0: 0
Elo1: 10
H1 was accepted
```
