### PR TITLE
Fail soft to return more accurate evals

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -120,7 +120,7 @@ int Searcher::search(int alpha, int beta, int depth, int distanceFromRoot) {
         
         // prune if a move is too good; opponent side will avoid playing into this node
         if (score >= beta) {
-            score = beta;
+            bestscore = score;
             break;
         }
         // fail-soft stabilizes the search and allows for returned values outside the alpha-beta bounds
@@ -137,7 +137,7 @@ int Searcher::search(int alpha, int beta, int depth, int distanceFromRoot) {
     }
     // A search for this depth is complete with a best move, so it can be stored in the transposition table
     this->storeInTT(entry, bestMove, depth);
-    return score;
+    return bestscore;
 }
 
 int Searcher::quiesce(int alpha, int beta, int depth, int distanceFromRoot) {


### PR DESCRIPTION
Some positions don't have evals returned correctly because fail hard for beta discards the true value of positions. For example, this fen `8/8/8/3k4/4p3/3bK3/1r6/5r2 b - - 1 61` doesn't correctly return a mate score but a eval of 0, even if the best move is given. This fixes that.

Bench: 28577791 (no change)

