### PR TITLE
Principle Variation Search

### DIFF
--- a/src/moveOrder.cpp
+++ b/src/moveOrder.cpp
@@ -39,6 +39,11 @@ bool MovePicker::movesLeft() const {
     return this->movesPicked < this->size;
 }
 
+
+int MovePicker::getMovesPicked() const {
+    return this->movesPicked;
+}
+
 // Due to pruning, we don't need to sort the entire array of moves for move ordering.
 // When sorting only small portions of arrays, using partial insertion sort is faster.
 BoardMove MovePicker::pickMove() {

--- a/src/moveOrder.hpp
+++ b/src/moveOrder.hpp
@@ -19,6 +19,7 @@ class MovePicker {
         MovePicker(std::vector<BoardMove>&& a_moves); 
         void assignMoveScores(const Board& board, BoardMove PVNode = BoardMove());
         bool movesLeft() const;
+        int getMovesPicked() const;
         BoardMove pickMove();
 
     private:

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -56,6 +56,7 @@ Info Searcher::startThinking() {
 
 template <NodeTypes NODE>
 int Searcher::search(int alpha, int beta, int depth, int distanceFromRoot) {
+    constexpr bool ISPV = NODE != NOTPV;
 
     // time up
     int score = 0;
@@ -109,8 +110,17 @@ int Searcher::search(int alpha, int beta, int depth, int distanceFromRoot) {
     BoardMove bestMove;
     while (movePicker.movesLeft()) {
         BoardMove move = movePicker.pickMove();
+        /*************
+         * Principle Variation Search:
+        **************/
         board.makeMove(move);
-        score = -search<PV>(-beta, -alpha, depth - 1, distanceFromRoot + 1);
+        if (ISPV && movePicker.getMovesPicked() == 1) {
+            score = -search<PV>(-beta, -alpha, depth - 1, distanceFromRoot + 1);
+        } else {
+            score = -search<NOTPV>(-alpha - 1, -alpha, depth - 1, distanceFromRoot + 1);
+            if (score > alpha && score < beta)
+                score = -search<PV>(-beta, -alpha, depth - 1, distanceFromRoot + 1);
+        }
         board.undoMove(); 
 
         // don't update best move if time is up

--- a/src/types.hpp
+++ b/src/types.hpp
@@ -35,7 +35,7 @@ enum castleRights {
 };
 
 enum NodeTypes {
-    ROOT, PV,
+    ROOT, PV, NOTPV
 };
 
 // indices are equal to the enumerated pieceTypes

--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -136,7 +136,7 @@ void go(std::istringstream& input, Board& board) {
         else if (param == "btime") {btime = std::stoi(value);}
         else if (param == "winc") {winc = std::stoi(value);}
         else if (param == "binc") {binc = std::stoi(value);}
-    }   
+    }
     int allytime = board.isWhiteTurn ? wtime : btime;
     int allyInc = board.isWhiteTurn ? winc : binc;
     Timeman::TimeManager tm(allytime, allyInc);


### PR DESCRIPTION
Principle Variation Search searches for null windows first for non-PV moves so that bad moves can be rejected quicker. It is surprising that there wasn't more of an elo gain considering how much the bench lowered.

```
Advancement Test:
Time Control: 10s + 0.1s
Games: N=3382 W=1395 L=1265 D=722
Elo: 13.4 +/- 10.4
Bench: 17744734

Alpha: 0.05
Beta: 0.05
Elo0: 0
Elo1: 10
H1 was accepted
```
