### PR TITLE
Return evaluations from transposition tables

### DIFF
--- a/src/moveOrder.cpp
+++ b/src/moveOrder.cpp
@@ -17,10 +17,10 @@ MovePicker::MovePicker(std::vector<BoardMove>&& a_moves) {
 
 // Searching moves that are likely to be better helps with pruning in search. This is move ordering.
 // More promising moves are given higher scores and then searched first.
-void MovePicker::assignMoveScores(const Board& board, BoardMove PVNode) {
+void MovePicker::assignMoveScores(const Board& board, BoardMove TTMove) {
     size_t i = 0;
     for (BoardMove move: this->moves) {
-        if (move == PVNode) {
+        if (move == TTMove) {
             this->moveScores[i] = MoveScores::PV;
         }
         else if (board.getPiece(move.pos2) != EmptyPiece) {

--- a/src/moveOrder.hpp
+++ b/src/moveOrder.hpp
@@ -17,7 +17,7 @@ enum MoveScores {
 class MovePicker {
     public:
         MovePicker(std::vector<BoardMove>&& a_moves); 
-        void assignMoveScores(const Board& board, BoardMove PVNode = BoardMove());
+        void assignMoveScores(const Board& board, BoardMove TTMove = BoardMove());
         bool movesLeft() const;
         int getMovesPicked() const;
         BoardMove pickMove();

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1,4 +1,3 @@
-#include <cassert>
 #include <iostream>
 #include <vector>
 
@@ -103,13 +102,10 @@ int Searcher::search(int alpha, int beta, int depth, int distanceFromRoot) {
     if (TTable::table.entryExists(this->board.zobristKey)) {
         entry = TTable::table.getEntry(this->board.zobristKey);
 
-        if (!ISROOT && entry.depth >= depth) {
+        if (!ISPV && entry.depth >= depth) {
             if (entry.flag == EvalType::EXACT
                 || (entry.flag == EvalType::UPPER && entry.eval <= alpha)
                 || (entry.flag == EvalType::LOWER && entry.eval >= beta)) {
-                
-                // prevents premature search ends
-                this->max_seldepth = std::max(entry.depth, this->max_seldepth);
                 return entry.eval;
             }
         }

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -71,7 +71,7 @@ int Searcher::search(int alpha, int beta, int depth, int distanceFromRoot) {
     this->max_seldepth = std::max(distanceFromRoot, this->max_seldepth);
 
     // fifty move rule
-    if (this->board.fiftyMoveRule == 100) {
+    if (this->board.fiftyMoveRule >= 100) {
         return score;
     }
     // three-fold repetition
@@ -79,7 +79,7 @@ int Searcher::search(int alpha, int beta, int depth, int distanceFromRoot) {
     std::sort(currKeyHistory.begin(), currKeyHistory.end());
     auto lBound = std::lower_bound(currKeyHistory.begin(), currKeyHistory.end(), this->board.zobristKey);
     auto rBound = std::upper_bound(currKeyHistory.begin(), currKeyHistory.end(), this->board.zobristKey);
-    if (distance(lBound, rBound) == 3) {
+    if (distance(lBound, rBound) >= 3) {
         return score;
     }
     // max depth reached
@@ -107,6 +107,9 @@ int Searcher::search(int alpha, int beta, int depth, int distanceFromRoot) {
             if (entry.flag == EvalType::EXACT
                 || (entry.flag == EvalType::UPPER && entry.eval <= alpha)
                 || (entry.flag == EvalType::LOWER && entry.eval >= beta)) {
+                
+                // prevents premature search ends
+                this->max_seldepth = std::max(entry.depth, this->max_seldepth);
                 return entry.eval;
             }
         }

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -105,7 +105,9 @@ int Searcher::search(int alpha, int beta, int depth, int distanceFromRoot) {
         entry = TTable::table.getEntry(posIndex);
 
         if (!ISROOT && entry.depth >= depth) {
-            if (entry.flag == TTable::EvalType::EXACT) {
+            if (entry.flag == TTable::EvalType::EXACT
+                || (entry.flag == TTable::EvalType::UPPER && entry.eval <= alpha)
+                || (entry.flag == TTable::EvalType::LOWER && entry.eval >= beta)) {
                 return entry.eval;
             }
         }
@@ -137,7 +139,7 @@ int Searcher::search(int alpha, int beta, int depth, int distanceFromRoot) {
 
         // don't update best move if time is up
         if (this->tm.hardTimeUp()) {
-            return score;
+            return bestscore;
         }
         
         // prune if a move is too good; opponent side will avoid playing into this node

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -58,8 +58,8 @@ Info Searcher::startThinking() {
 template <NodeTypes NODE>
 int Searcher::search(int alpha, int beta, int depth, int distanceFromRoot) {
     constexpr bool ISROOT = NODE == ROOT;
-    const int oldAlpha = alpha;
     constexpr bool ISPV = NODE != NOTPV;
+    const int oldAlpha = alpha;
 
     // time up
     int score = 0;
@@ -100,14 +100,13 @@ int Searcher::search(int alpha, int beta, int depth, int distanceFromRoot) {
     *************/
     BoardMove TTMove;
     TTable::Entry entry;
-    int posIndex = TTable::table.getIndex(this->board.zobristKey);
     if (TTable::table.entryExists(this->board.zobristKey)) {
-        entry = TTable::table.getEntry(posIndex);
+        entry = TTable::table.getEntry(this->board.zobristKey);
 
         if (!ISROOT && entry.depth >= depth) {
-            if (entry.flag == TTable::EvalType::EXACT
-                || (entry.flag == TTable::EvalType::UPPER && entry.eval <= alpha)
-                || (entry.flag == TTable::EvalType::LOWER && entry.eval >= beta)) {
+            if (entry.flag == EvalType::EXACT
+                || (entry.flag == EvalType::UPPER && entry.eval <= alpha)
+                || (entry.flag == EvalType::LOWER && entry.eval >= beta)) {
                 return entry.eval;
             }
         }
@@ -160,8 +159,7 @@ int Searcher::search(int alpha, int beta, int depth, int distanceFromRoot) {
         }
     }
     // A search for this depth is complete with a best move, so it can be stored in the transposition table
-    entry.flag = (bestscore >= beta) ? TTable::EvalType::LOWER :
-                    (alpha == oldAlpha) ? TTable::EvalType::UPPER : TTable::EvalType::EXACT;
+    entry.flag = (bestscore >= beta) ? EvalType::LOWER : (alpha == oldAlpha) ? EvalType::UPPER : EvalType::EXACT;
     this->storeInTT(entry, bestscore, bestMove, depth);
     return bestscore;
 }
@@ -205,7 +203,6 @@ int Searcher::quiesce(int alpha, int beta, int depth, int distanceFromRoot) {
 }
 
 void Searcher::storeInTT(TTable::Entry entry, int eval, BoardMove move, int depth) {
-    int posIndex = TTable::table.getIndex(this->board.zobristKey);
     /* entries in the transposition table are overwritten under two conditions:
     1. The current search depth is greater than the entry's depth, meaning that a better
     search has been performed 
@@ -220,7 +217,7 @@ void Searcher::storeInTT(TTable::Entry entry, int eval, BoardMove move, int dept
             entry.depth = depth;
             entry.eval = eval;
             entry.move = move;
-            TTable::table.storeEntry(posIndex, entry);
+            TTable::table.storeEntry(entry.key, entry);
     }
 }
 

--- a/src/search.hpp
+++ b/src/search.hpp
@@ -38,7 +38,7 @@ class Searcher {
         template <NodeTypes NODE>
         int search(int alpha, int beta, int depth, int distanceFromRoot);
         int quiesce(int alpha, int beta, int depth, int distanceFromRoot);
-        void storeInTT(TTable::Entry entry, BoardMove move, int depth);
+        void storeInTT(TTable::Entry entry, int eval, BoardMove move, int depth);
 
         void outputUciInfo(Info searchResult);
         void setPrintInfo(bool flag) {this->printInfo = flag;}; 

--- a/src/ttable.cpp
+++ b/src/ttable.cpp
@@ -37,12 +37,12 @@ bool TTable::entryExists(uint64_t key) const {
     return key == this->table[index].key;
 }
 
-Entry TTable::getEntry(int index) const {
-    return this->table[index];
+Entry TTable::getEntry(uint64_t key) const {
+    return this->table[this->getIndex(key)];
 }
 
-void TTable::storeEntry(int index, Entry entry) {
-    this->table[index] = entry;
+void TTable::storeEntry(uint64_t key, Entry entry) {
+    this->table[this->getIndex(key)] = entry;
 }
 
 int TTable::getIndex(uint64_t key) const {

--- a/src/ttable.hpp
+++ b/src/ttable.hpp
@@ -5,13 +5,14 @@
 
 #include "move.hpp"
 
+enum EvalType {
+    UPPER, LOWER, EXACT, NONE
+};
+
 namespace TTable {
 
 constexpr int DEFAULT_SIZEMB = 128;
 
-enum EvalType {
-    UPPER, LOWER, EXACT, NONE
-};
 
 struct Entry {
     uint64_t key = 0;
@@ -21,6 +22,7 @@ struct Entry {
     EvalType flag = NONE;
     BoardMove move = BoardMove();
 };
+
 class TTable {
     public:
         void resize(int sizeMb);
@@ -28,10 +30,10 @@ class TTable {
         void clear();
         int hashFull();
 
-        int getIndex(uint64_t key) const;
         bool entryExists(uint64_t key) const;
-        Entry getEntry(int index) const;
-        void storeEntry(int index, Entry entry);
+        Entry getEntry(uint64_t key) const;
+        void storeEntry(uint64_t key, Entry entry);
+        int getIndex(uint64_t key) const;
     private:
         std::vector<Entry> table;
         int size;

--- a/src/ttable.hpp
+++ b/src/ttable.hpp
@@ -9,13 +9,18 @@ namespace TTable {
 
 constexpr int DEFAULT_SIZEMB = 128;
 
+enum EvalType {
+    UPPER, LOWER, EXACT, NONE
+};
+
 struct Entry {
     uint64_t key = 0;
     uint8_t age = 0;
     int depth = 0;
+    int eval = 0;
+    EvalType flag = NONE;
     BoardMove move = BoardMove();
 };
-
 class TTable {
     public:
         void resize(int sizeMb);


### PR DESCRIPTION
Evaluations can now be directly returned from the transposition table instead of it just being used for move ordering, which speeds up the time needed for a search. There are also some cleanups, like using key directly to store entries instead of needing an index first.

```
Advancement Test:
Time Control: 10s + 0.1s
Games: N=504 W=244 L=156 D=104
Elo: 61.3 +/- 27.4
Bench: 13841985

Alpha: 0.05
Beta: 0.05
Elo0: 0
Elo1: 10
H1 was accepted
```