### PR TITLE
3fold detection speedup

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1,3 +1,4 @@
+#include <algorithm>
 #include <iostream>
 #include <vector>
 
@@ -74,11 +75,8 @@ int Searcher::search(int alpha, int beta, int depth, int distanceFromRoot) {
         return score;
     }
     // three-fold repetition
-    std::vector<uint64_t> currKeyHistory = this->board.zobristKeyHistory;
-    std::sort(currKeyHistory.begin(), currKeyHistory.end());
-    auto lBound = std::lower_bound(currKeyHistory.begin(), currKeyHistory.end(), this->board.zobristKey);
-    auto rBound = std::upper_bound(currKeyHistory.begin(), currKeyHistory.end(), this->board.zobristKey);
-    if (distance(lBound, rBound) >= 3) {
+    int occurrences = std::count(this->board.zobristKeyHistory.begin(), this->board.zobristKeyHistory.end(), this->board.zobristKey);
+    if (occurrences >= 3) {
         return score;
     }
     // max depth reached


### PR DESCRIPTION
Instead of sorting and using a linear scan after, it's better to just use a linear scan to find 3fold repetition instances. I didn't complete the SPRT for reasons, but it's not really needed to merge something like this:

```
Advancement Test:
Time Control: 10s + 0.1s
Games: N=2435 W=1024 L=936 D=475
Elo: 12.6+/- 12.4
Bench: 13841985 (Unchanged)

Alpha: 0.05
Beta: 0.05
Elo0: 0
Elo1: 10
Incomplete: LLR 1.89
```
