### PR TITLE
Null Move Pruning

### DIFF
--- a/src/board.cpp
+++ b/src/board.cpp
@@ -287,17 +287,23 @@ void Board::makeNullMove() {
         this->enPassSquare,
         this->fiftyMoveRule
     ));
+    if (this->enPassSquare) {
+        this->zobristKey ^= Zobrist::enPassKeys[getFile(this->enPassSquare)];
+        this->enPassSquare = NULLSQUARE;
+    }
     this->isWhiteTurn = !this->isWhiteTurn; 
-    this->zobristKey ^= Zobrist::isBlackKey;
+    this->fiftyMoveRule++;
     this->age++;
 
+    this->zobristKey ^= Zobrist::isBlackKey;
     this->zobristKeyHistory.push_back(this->zobristKey);
 }
 
 void Board::unmakeNullMove() {
     this->enPassSquare = moveHistory.back().enPassSquare;
     this->isWhiteTurn = !this->isWhiteTurn; 
-    this->age++;
+    this->fiftyMoveRule--;
+    this->age--;
 
     this->moveHistory.pop_back();
     this->zobristKeyHistory.pop_back();

--- a/src/board.cpp
+++ b/src/board.cpp
@@ -291,7 +291,7 @@ void Board::makeNullMove() {
         this->zobristKey ^= Zobrist::enPassKeys[getFile(this->enPassSquare)];
         this->enPassSquare = NULLSQUARE;
     }
-    this->isWhiteTurn = !this->isWhiteTurn; 
+    this->isWhiteTurn = !this->isWhiteTurn;
     this->fiftyMoveRule++;
     this->age++;
 
@@ -301,7 +301,7 @@ void Board::makeNullMove() {
 
 void Board::unmakeNullMove() {
     this->enPassSquare = moveHistory.back().enPassSquare;
-    this->isWhiteTurn = !this->isWhiteTurn; 
+    this->isWhiteTurn = !this->isWhiteTurn;
     this->fiftyMoveRule--;
     this->age--;
 

--- a/src/board.cpp
+++ b/src/board.cpp
@@ -278,6 +278,32 @@ void Board::undoMove() {
     this->zobristKey = zobristKeyHistory.back();
 }
 
+void Board::makeNullMove() {
+    this->moveHistory.push_back(BoardState(
+        BoardMove(),
+        EmptyPiece,
+        EmptyPiece,
+        this->castlingRights,
+        this->enPassSquare,
+        this->fiftyMoveRule
+    ));
+    this->isWhiteTurn = !this->isWhiteTurn; 
+    this->zobristKey ^= Zobrist::isBlackKey;
+    this->age++;
+
+    this->zobristKeyHistory.push_back(this->zobristKey);
+}
+
+void Board::unmakeNullMove() {
+    this->enPassSquare = moveHistory.back().enPassSquare;
+    this->isWhiteTurn = !this->isWhiteTurn; 
+    this->age++;
+
+    this->moveHistory.pop_back();
+    this->zobristKeyHistory.pop_back();
+    this->zobristKey = zobristKeyHistory.back();
+}
+
 bool Board::moveIsCapture(BoardMove move) {
     if(this->getPiece(move.sqr1()) % 6 == WPawn && this->enPassSquare == move.sqr2())
         return true;
@@ -367,7 +393,11 @@ int Board::evaluate() const {
 }
 
 bool operator==(const Board& lhs, const Board& rhs) {
-    return (lhs.board == rhs.board) && (lhs.pieceSets == rhs.pieceSets) && (lhs.zobristKeyHistory == rhs.zobristKeyHistory);
+    return lhs.board == rhs.board
+        && lhs.pieceSets == rhs.pieceSets
+        && lhs.zobristKeyHistory == rhs.zobristKeyHistory
+        && lhs.isWhiteTurn == rhs.isWhiteTurn
+        && lhs.enPassSquare == rhs.enPassSquare;
 }
 
 std::ostream& operator<<(std::ostream& os, const Board& target) {

--- a/src/board.hpp
+++ b/src/board.hpp
@@ -29,6 +29,8 @@ struct Board {
     
     void makeMove(BoardMove move);
     void undoMove();
+    void makeNullMove();
+    void unmakeNullMove();
     
     pieceTypes getPiece(Square square) const;
     void setPiece(Square square, pieceTypes currPiece);

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -114,7 +114,7 @@ int Searcher::search(int alpha, int beta, int depth, int distanceFromRoot) {
     /************
      * Null Move Pruning
     *************/
-    if (depth >= 2) { // turn changes work weird with depth = 1
+    if (depth >= 2 && !currKingInAttack(board.pieceSets, board.isWhiteTurn)) {
         board.makeNullMove();
         int nullMoveScore = -search<NOTPV>(-beta, -beta + 1, depth - 1, distanceFromRoot + 1);
         board.unmakeNullMove();

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -116,7 +116,7 @@ int Searcher::search(int alpha, int beta, int depth, int distanceFromRoot) {
     *************/
     if (depth >= 2 && !currKingInAttack(board.pieceSets, board.isWhiteTurn)) {
         board.makeNullMove();
-        int nullMoveScore = -search<NOTPV>(-beta, -beta + 1, depth - 1, distanceFromRoot + 1);
+        int nullMoveScore = -search<NOTPV>(-beta, -beta + 1, depth - 2, distanceFromRoot + 1);
         board.unmakeNullMove();
         if (nullMoveScore >= beta) {
             return nullMoveScore;

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -80,7 +80,7 @@ int Searcher::search(int alpha, int beta, int depth, int distanceFromRoot) {
         return score;
     }
     // max depth reached
-    if (depth == 0) {
+    if (depth <= 0) {
         return quiesce(alpha, beta, 5, distanceFromRoot);
     }
     // checkmate or stalemate
@@ -109,6 +109,18 @@ int Searcher::search(int alpha, int beta, int depth, int distanceFromRoot) {
         }
 
         TTMove = entry.move;
+    }
+
+    /************
+     * Null Move Pruning
+    *************/
+    if (depth >= 2) { // turn changes work weird with depth = 1
+        board.makeNullMove();
+        int nullMoveScore = -search<NOTPV>(-beta, -beta + 1, depth - 1, distanceFromRoot + 1);
+        board.unmakeNullMove();
+        if (nullMoveScore >= beta) {
+            return nullMoveScore;
+        }
     }
 
     // init movePicker

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -58,7 +58,8 @@ Info Searcher::startThinking() {
 template <NodeTypes NODE>
 int Searcher::search(int alpha, int beta, int depth, int distanceFromRoot) {
     constexpr bool ISROOT = NODE == ROOT;
-    constexpr bool ISPV = NODE != NOTPV;
+    constexpr bool ISPV = NODE == ROOT || NODE == PV;
+    constexpr bool ISNMP = NODE == NMP;
     const int oldAlpha = alpha;
 
     // time up
@@ -114,9 +115,9 @@ int Searcher::search(int alpha, int beta, int depth, int distanceFromRoot) {
     /************
      * Null Move Pruning
     *************/
-    if (depth >= 2 && !currKingInAttack(board.pieceSets, board.isWhiteTurn)) {
+    if (!ISNMP && depth >= 2 && !currKingInAttack(board.pieceSets, board.isWhiteTurn)) {
         board.makeNullMove();
-        int nullMoveScore = -search<NOTPV>(-beta, -beta + 1, depth - 2, distanceFromRoot + 1);
+        int nullMoveScore = -search<NMP>(-beta, -beta + 1, depth - 2, distanceFromRoot + 1);
         board.unmakeNullMove();
         if (nullMoveScore >= beta) {
             return nullMoveScore;

--- a/src/types.hpp
+++ b/src/types.hpp
@@ -37,7 +37,7 @@ enum castleRights {
 };
 
 enum NodeTypes {
-    ROOT, PV, NOTPV
+    ROOT, PV, NOTPV, NMP
 };
 
 // indices are equal to the enumerated pieceTypes


### PR DESCRIPTION
Nodes are pruned if a shallower search with a null move still fails high.

```
Advancement Test:
Time Control: 10s + 0.1s
Games: N=1088 W=483 L=385 D=220
Elo: 31.4 +/- 18.5
Bench: 6922089

Alpha: 0.05
Beta: 0.05
Elo0: 0
Elo1: 10
H1 was accepted
```
