### PR TITLE
Staged Move Generation

### DIFF
--- a/src/board.cpp
+++ b/src/board.cpp
@@ -310,8 +310,10 @@ void Board::unmakeNullMove() {
     this->zobristKey = zobristKeyHistory.back();
 }
 
-bool Board::moveIsCapture(BoardMove move) {
-    if(this->getPiece(move.sqr1()) % 6 == WPawn && this->enPassSquare == move.sqr2())
+bool Board::moveIsCapture(BoardMove move) const {
+    if ( (this->getPiece(move.sqr1()) == WPawn || this->getPiece(move.sqr1()) == BPawn) && this->enPassSquare == move.sqr2())
+        return true;
+    if (move.getPromotePiece() == WQueen || move.getPromotePiece() == BQueen)
         return true;
     return this->getPiece(move.sqr2()) != EmptyPiece;
 }

--- a/src/board.hpp
+++ b/src/board.hpp
@@ -34,7 +34,7 @@ struct Board {
     
     pieceTypes getPiece(Square square) const;
     void setPiece(Square square, pieceTypes currPiece);
-    bool moveIsCapture(BoardMove move);
+    bool moveIsCapture(BoardMove move) const;
     
     bool isLegalMove(const BoardMove move) const;
     int evaluate() const;

--- a/src/move.hpp
+++ b/src/move.hpp
@@ -24,8 +24,7 @@ class BoardMove {
         int toInt(pieceTypes piece) const;
         std::string toStr(pieceTypes piece) const;
 
-        uint16_t data;
-
+        uint16_t data{};
     friend std::ostream& operator<<(std::ostream& os, const BoardMove& target);
     friend bool operator==(const BoardMove& lhs, const BoardMove& rhs);
     friend bool operator!=(const BoardMove& lhs, const BoardMove& rhs);

--- a/src/moveGen.cpp
+++ b/src/moveGen.cpp
@@ -68,7 +68,7 @@ void MoveList::generateQuiets(const Board& board) {
     uint64_t validDests = this->emptySquares;
     this->pawnStartRank   = board.isWhiteTurn ? RANK_2 : RANK_7;
     this->pawnJumpRank    = board.isWhiteTurn ? RANK_4 : RANK_5;
-    this->castlingRights = board.castlingRights;
+    this->castlingRights  = board.castlingRights;
     this->castlingRights &= board.isWhiteTurn ? W_Castle : B_Castle;
     
     auto knightMovesFunc = [this](Square piece, uint64_t vd) {return this->knightMoves(piece, vd);};
@@ -169,7 +169,7 @@ uint64_t MoveList::pawnCaptures(int square, uint64_t validDests) const {
 }
 
 uint64_t MoveList::pawnPushes(int square, uint64_t validDests) const {
-    uint64_t dests, pawn = c_u64(1) << square;
+    uint64_t dests = 0, pawn = c_u64(1) << square;
     uint64_t currFile = FILES_MASK[getFile(square)];
     // one space forward
     if (this->isWhiteTurn) {

--- a/src/moveGen.hpp
+++ b/src/moveGen.hpp
@@ -14,7 +14,7 @@ class MoveList {
         void generateCaptures(const Board& board);
         void generateQuiets(const Board& board);
 
-        std::vector<BoardMove> moves;
+        std::vector<BoardMove> moves{};
     private:
         template<typename Func>
         void generatePieceMoves(uint64_t pieces, uint64_t validDests, Func pieceMoves, const Board& board);
@@ -30,10 +30,13 @@ class MoveList {
         uint64_t pawnPushes(int square, uint64_t validDests) const;
         uint64_t kingCastles(std::array<uint64_t, NUM_BITBOARDS> pieceSets);
 
-        uint64_t pawns, promotingPawns, bishops, knights, rooks, queens, kings;
-        uint64_t allPieces, emptySquares, notAllies;
-        uint64_t pawnStartRank, pawnJumpRank, pawnPromoteRank;
-        uint64_t castlingRights;
-        Square enPassSquare;
-        bool isWhiteTurn;
+        // used by both captures and quiets
+        uint64_t pawns{}, promotingPawns{}, bishops{}, knights{}, rooks{}, queens{}, kings{};
+        uint64_t allPieces{}, emptySquares{};
+        bool isWhiteTurn{};
+        // used by captures
+        Square enPassSquare{};
+        // used by quiets
+        uint64_t pawnStartRank{}, pawnJumpRank{};
+        uint64_t castlingRights{};
 };

--- a/src/moveGen.hpp
+++ b/src/moveGen.hpp
@@ -8,6 +8,7 @@
 
 class MoveList {
     public:
+        MoveList() = default;
         MoveList(const Board& board);
         void generateAllMoves(const Board& board);
         void generateCaptures(const Board& board);

--- a/src/moveGen.hpp
+++ b/src/moveGen.hpp
@@ -6,26 +6,33 @@
 
 #include "board.hpp"
 
-namespace MoveGen {
+class MoveList {
+    public:
+        MoveList(const Board& board);
+        void generateAllMoves(const Board& board);
+        void generateCaptures(const Board& board);
+        void generateQuiets(const Board& board);
 
-struct MoveGenInfo {
-    uint64_t allPieces, emptySquares, notAllies; 
-    uint64_t pawnEnemies, pawnStartRank, pawnJumpRank;
-    std::array<uint64_t, NUM_BITBOARDS> pieceSets;
-    uint64_t castlingRights;
-    bool isWhiteTurn;
+        std::vector<BoardMove> moves;
+    private:
+        template<typename Func>
+        void generatePieceMoves(uint64_t pieces, uint64_t validDests, Func pieceMoves, const Board& board);
+        template<typename Func>
+        void generatePawnPromotions(uint64_t pieces, uint64_t validDests, Func pieceMoves, const Board& board, const bool QUEENS);
+        void generateKingCastles(const Board& board);
+
+        uint64_t knightMoves(int square, uint64_t validDests) const;
+        uint64_t bishopMoves(int square, uint64_t validDests) const;
+        uint64_t rookMoves(int square, uint64_t validDests) const;
+        uint64_t kingMoves(int square, uint64_t validDests) const;
+        uint64_t pawnCaptures(int square, uint64_t validDests) const;
+        uint64_t pawnPushes(int square, uint64_t validDests) const;
+        uint64_t kingCastles(std::array<uint64_t, NUM_BITBOARDS> pieceSets);
+
+        uint64_t pawns, promotingPawns, bishops, knights, rooks, queens, kings;
+        uint64_t allPieces, emptySquares, notAllies;
+        uint64_t pawnStartRank, pawnJumpRank, pawnPromoteRank;
+        uint64_t castlingRights;
+        Square enPassSquare;
+        bool isWhiteTurn;
 };
-
-std::vector<BoardMove> moveGenerator(Board board); // outputs board instead of board moves for future evaluation functions
-
-template<typename Func>
-void validPieceMoves(uint64_t pieces, Func pieceMoves, MoveGenInfo& colors, Board& board, std::vector<BoardMove>& validMoves);
-void validPawnMoves(uint64_t pawns, MoveGenInfo& colors, Board& board, std::vector<BoardMove>& validMoves); // includes en passant
-
-uint64_t knightMoves(int square, MoveGenInfo& info);
-uint64_t bishopMoves(int square, MoveGenInfo& info);
-uint64_t rookMoves(int square, MoveGenInfo& info);
-uint64_t kingMoves(int square, MoveGenInfo& info);
-uint64_t pawnMoves(int square, MoveGenInfo& info, bool isWhiteTurn);
-
-} // namespace MoveGen

--- a/src/moveOrder.cpp
+++ b/src/moveOrder.cpp
@@ -45,8 +45,8 @@ void MovePicker::assignMoveScores(const Board& board) {
             this->moveScores[i] = MoveScores::PV;
         }
         else if (ASSIGN_CAPTURES && board.moveIsCapture(move)) {
+            int victimValue = this->getVictimScore(board, move);
             int attackerValue = pieceValues[board.getPiece(move.sqr1())];
-            int victimValue = pieceValues[board.getPiece(move.sqr2())];
             this->moveScores[i] = MoveScores::Capture + victimValue - attackerValue;
         }
         else {
@@ -84,6 +84,14 @@ BoardMove MovePicker::pickMove() {
     
     ++this->movesPicked;
     return move;
+}
+
+int MovePicker::getVictimScore(const Board& board, BoardMove move) const {
+    if ( (board.getPiece(move.sqr1()) == WPawn || board.getPiece(move.sqr1()) == BPawn) && board.enPassSquare == move.sqr2())
+        return pieceValues[WPawn];
+    else if (move.getPromotePiece() != EmptyPiece)
+        return pieceValues[move.getPromotePiece()];
+    return pieceValues[board.getPiece(move.sqr2())];
 }
 
 } // namespace MoveOrder

--- a/src/moveOrder.hpp
+++ b/src/moveOrder.hpp
@@ -35,4 +35,12 @@ class MovePicker {
         unsigned int movesPicked;
 };
 
+constexpr inline Stage operator^(Stage lhs, Stage rhs) {
+    return static_cast<Stage>(static_cast<int>(lhs) ^ static_cast<int>(rhs));
+}
+
+constexpr inline Stage& operator^=(Stage& lhs, Stage rhs) {
+    return lhs = lhs ^ rhs;
+}
+
 } // namespace MoveOrder

--- a/src/moveOrder.hpp
+++ b/src/moveOrder.hpp
@@ -2,31 +2,37 @@
 
 #include <vector>
 
+#include "moveGen.hpp"
 #include "board.hpp"
 #include "move.hpp"
 #include "types.hpp"
 
 namespace MoveOrder { 
 
-enum MoveScores {
-    PV = 1 << 20,
-    Capture = 1 << 10,
-    Quiet = 0,
+enum Stage {
+    Captures = 0b01, Quiets = 0b10, All = Captures | Quiets
 };
 
 class MovePicker {
     public:
-        MovePicker(std::vector<BoardMove>&& a_moves); 
-        void assignMoveScores(const Board& board, BoardMove TTMove = BoardMove());
-        bool movesLeft() const;
+        MovePicker(const Board& board, Stage a_stage, BoardMove a_TTMove = BoardMove());
+        bool movesLeft(const Board& board);
         int getMovesPicked() const;
         BoardMove pickMove();
-
     private:
-        std::vector<BoardMove> moves;
+        enum MoveScores {
+            PV = 1 << 20,
+            Capture = 1 << 10,
+            Quiet = 0,
+        };
+
+        void assignMoveScores(const Board& board);
+
+        MoveList moveList;
         std::vector<int> moveScores;
-        int movesPicked;
-        int size;
+        Stage stage;
+        BoardMove TTMove;
+        unsigned int movesPicked;
 };
 
 } // namespace MoveOrder

--- a/src/moveOrder.hpp
+++ b/src/moveOrder.hpp
@@ -10,7 +10,7 @@
 namespace MoveOrder { 
 
 enum Stage {
-    Captures = 0b01, Quiets = 0b10, All = Captures | Quiets
+    None = 0, Captures = 0b01, Quiets = 0b10, All = Captures | Quiets
 };
 
 class MovePicker {
@@ -26,21 +26,18 @@ class MovePicker {
             Quiet = 0,
         };
 
+        template<bool ASSIGN_TTMOVE, Stage STAGE>
         void assignMoveScores(const Board& board);
 
         MoveList moveList;
-        std::vector<int> moveScores;
+        std::array<int, MAX_MOVES> moveScores;
         Stage stage;
         BoardMove TTMove;
         unsigned int movesPicked;
 };
 
-constexpr inline Stage operator^(Stage lhs, Stage rhs) {
-    return static_cast<Stage>(static_cast<int>(lhs) ^ static_cast<int>(rhs));
-}
-
-constexpr inline Stage& operator^=(Stage& lhs, Stage rhs) {
-    return lhs = lhs ^ rhs;
+constexpr inline Stage operator&(Stage lhs, Stage rhs) {
+    return static_cast<Stage>(static_cast<int>(lhs) & static_cast<int>(rhs));
 }
 
 } // namespace MoveOrder

--- a/src/moveOrder.hpp
+++ b/src/moveOrder.hpp
@@ -28,6 +28,7 @@ class MovePicker {
 
         template<bool ASSIGN_TTMOVE, Stage STAGE>
         void assignMoveScores(const Board& board);
+        int getVictimScore(const Board& board, BoardMove move) const;
 
         MoveList moveList;
         std::array<int, MAX_MOVES> moveScores;

--- a/src/perft.hpp
+++ b/src/perft.hpp
@@ -15,13 +15,14 @@ uint64_t perft(Board board, int depthLeft) {
         return 1;
     }
 
-    std::vector<BoardMove> moves = MoveGen::moveGenerator(board);
+    MoveList gen(board);
+    gen.generateAllMoves(board);
     if (depthLeft == 1 && !printMoves) {
-       return moves.size();
+       return gen.moves.size();
     }
 
     uint64_t leafNodeCount = 0;
-    for (auto move: moves) {
+    for (auto move: gen.moves) {
         board.makeMove(move);
         uint64_t moveCount = perft<false>(board, depthLeft - 1);
         leafNodeCount += moveCount;

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -189,7 +189,7 @@ int Searcher::quiesce(int alpha, int beta, int depth, int distanceFromRoot) {
     if(depth == 0)
         return stand_pat;
 
-    MoveOrder::MovePicker movePicker(board, MoveOrder::Captures, BoardMove());
+    MoveOrder::MovePicker movePicker(board, MoveOrder::Captures);
     int score = MIN_ALPHA;
     while (movePicker.movesLeft(board)) {
         BoardMove move = movePicker.pickMove();

--- a/src/types.hpp
+++ b/src/types.hpp
@@ -10,6 +10,7 @@ constexpr int BOARD_SIZE = 64;
 constexpr int NUM_BITBOARDS = 14;
 constexpr int NUM_COLORED_PIECES = 12;
 constexpr int NUM_PIECES = 6;
+constexpr int MAX_MOVES = 256;
 
 enum pieceTypes {EmptyPiece = -1,
                 WKing, WQueen, WBishop, WKnight, WRook, WPawn, 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -26,6 +26,7 @@ add_executable(allTests
     ../src/moveOrder.cpp
     ../src/timeman.cpp
     ../src/ttable.cpp
+    ../src/search.cpp
     ../src/eval.cpp
 )
 target_include_directories(allTests PUBLIC "../src/")

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -26,7 +26,6 @@ add_executable(allTests
     ../src/moveOrder.cpp
     ../src/timeman.cpp
     ../src/ttable.cpp
-    ../src/search.cpp
     ../src/eval.cpp
 )
 target_include_directories(allTests PUBLIC "../src/")

--- a/tests/testMoveGen.cpp
+++ b/tests/testMoveGen.cpp
@@ -9,7 +9,6 @@
 #include <algorithm>
 #include <vector>
 
-using namespace MoveGen;
 class MoveGenTest : public testing::Test {
     public:
         static void SetUpTestSuite() {
@@ -19,100 +18,101 @@ class MoveGenTest : public testing::Test {
 
 TEST_F(MoveGenTest, validPawnMovesCaptures) {
     Board board("7k/8/8/p1p14/KP1P4/8/6P1/8 w - - 0 1");
-    std::vector<BoardMove> moves = MoveGen::moveGenerator(board);
-    ASSERT_EQ(moves.size(), 11);
+    MoveList moveGen(board);
+    moveGen.generateAllMoves(board);
+    ASSERT_EQ(moveGen.moves.size(), 11);
 }
 
 TEST_F(MoveGenTest, validPawnMovesPromotion) {
     Board board("8/3P4/3K4/8/8/8/8/7k w - - 0 1");
-    std::vector<BoardMove> moves = MoveGen::moveGenerator(board);
-    ASSERT_EQ(moves.size(), 11);
+    MoveList moveGen(board);
+    moveGen.generateAllMoves(board);
+    ASSERT_EQ(moveGen.moves.size(), 11);
 }
 
 TEST_F(MoveGenTest, validKnightMoves1) {
     Board board("7k/8/8/8/3N4/8/2n1K3/N7 w - - 0 1");
-    std::vector<BoardMove> moves = MoveGen::moveGenerator(board);
-    ASSERT_EQ(moves.size(), 15);
+    MoveList moveGen(board);
+    moveGen.generateAllMoves(board);
+    ASSERT_EQ(moveGen.moves.size(), 15);
 }
 
 TEST_F(MoveGenTest, validRookMoves1) {
     Board board("BB5k/8/8/8/8/8/2K5/RR5r w - - 0 1");
-    std::vector<BoardMove> moves = MoveGen::moveGenerator(board);
-    ASSERT_EQ(moves.size(), 37);
+    MoveList moveGen(board);
+    moveGen.generateAllMoves(board);
+    ASSERT_EQ(moveGen.moves.size(), 37);
 }
 
 TEST_F(MoveGenTest, validBishopMoves1) {
     Board board("7k/8/5b2/8/3B4/8/8/BK6 w - - 0 1");
-    std::vector<BoardMove> moves = MoveGen::moveGenerator(board);
-    ASSERT_EQ(moves.size(), 16);
+    MoveList moveGen(board);
+    moveGen.generateAllMoves(board);
+    ASSERT_EQ(moveGen.moves.size(), 16);
 }
 
 TEST_F(MoveGenTest, validQueenMoves1) {
     Board board("3k4/8/8/8/8/8/2K5/Q6Q w - - 0 1");
-    std::vector<BoardMove> moves = MoveGen::moveGenerator(board);
-    ASSERT_EQ(moves.size(), 48);
+    MoveList moveGen(board);
+    moveGen.generateAllMoves(board);
+    ASSERT_EQ(moveGen.moves.size(), 48);
 }
 
 TEST_F(MoveGenTest, validKingMovesNoCastle) {
     Board board("7k/8/8/8/8/4p3/8/4K3 w - - 0 1");
-    std::vector<BoardMove> moves = MoveGen::moveGenerator(board);
-    ASSERT_EQ(moves.size(), 3);
+    MoveList moveGen(board);
+    moveGen.generateAllMoves(board);
+    ASSERT_EQ(moveGen.moves.size(), 3);
 }
 
 TEST_F(MoveGenTest, validKingMovesKingCastle) {
     Board board("4k3/8/8/8/8/8/8/R1B1K2R w KQ - 0 1");
-    std::vector<BoardMove> moves = MoveGen::moveGenerator(board);
-    ASSERT_EQ(moves.size(), 30);
+    MoveList moveGen(board);
+    moveGen.generateAllMoves(board);
+    ASSERT_EQ(moveGen.moves.size(), 30);
 }
 
 TEST_F(MoveGenTest, validKingMovesQueenCastle) {
     Board board("4k3/8/8/8/8/8/8/R3K1BR w KQ - 0 1");
-    std::vector<BoardMove> moves = MoveGen::moveGenerator(board);
-    ASSERT_EQ(moves.size(), 30);
+    MoveList moveGen(board);
+    moveGen.generateAllMoves(board);
+    ASSERT_EQ(moveGen.moves.size(), 30);
 }
 
 TEST_F(MoveGenTest, validKingMovesInvalidCastle) {
     Board board("3qk3/8/8/8/8/8/8/R3K1BR w KQkq - 0 1");
-    std::vector<BoardMove> moves = MoveGen::moveGenerator(board);
-    ASSERT_EQ(moves.size(), 27);
+    MoveList moveGen(board);
+    moveGen.generateAllMoves(board);
+    ASSERT_EQ(moveGen.moves.size(), 27);
 }
 
 TEST_F(MoveGenTest, moveGeneratorDefault) {
     Board board;
-    std::vector<BoardMove> moves = moveGenerator(board);
-    EXPECT_EQ(moves.size(), 20);
+    MoveList moveGen(board);
+    moveGen.generateAllMoves(board);
+    ASSERT_EQ(moveGen.moves.size(), 20);
 }
 
 TEST_F(MoveGenTest, validKingMovesInvalidCastle2) {
     Board board("r2rk3/p4p1p/2p4b/2Q5/1P1Nq3/P1B2P1b/2P4P/R2K3R b q - 0 1");
-    std::vector<BoardMove> moves = moveGenerator(board);
-    EXPECT_EQ(moves.size(), 43);
+    MoveList moveGen(board);
+    moveGen.generateAllMoves(board);
+    ASSERT_EQ(moveGen.moves.size(), 43);
 }
 
 TEST_F(MoveGenTest, validKingMovesValidCastle3) {
     Board board("r3k3/pp1r1p1p/2B4b/5Q2/1P1Nq3/P1B4b/2P2P1P/R2K3R b q - 2 1");
-    std::vector<BoardMove> moves = moveGenerator(board);
-    EXPECT_EQ(moves.size(), 42);
+    MoveList moveGen(board);
+    moveGen.generateAllMoves(board);
+    ASSERT_EQ(moveGen.moves.size(), 42);
 }
 
 TEST_F(MoveGenTest, moveGeneratorBlackMove) {
     Board board;
     board.makeMove(BoardMove(toSquare("e2"), toSquare("e3")));
-    std::vector<BoardMove> expectedValidMoves;
-    for (int file = 0; file <= 7; file++) {
-        expectedValidMoves.push_back(BoardMove(toSquare(1, file), toSquare(2, file)));
-        expectedValidMoves.push_back(BoardMove(toSquare(1, file), toSquare(3, file)));
-    }
-    expectedValidMoves.push_back(BoardMove("b8a6", false));
-    expectedValidMoves.push_back(BoardMove("b8c6", false));
-    expectedValidMoves.push_back(BoardMove("g8f6", false));
-    expectedValidMoves.push_back(BoardMove("g8h6", false));
-    std::vector<BoardMove> validMoves = moveGenerator(board);
-
-    std::sort(validMoves.begin(), validMoves.end());
-    std::sort(expectedValidMoves.begin(), expectedValidMoves.end());
-    ASSERT_EQ(board.isWhiteTurn, false);
-    ASSERT_EQ(validMoves, expectedValidMoves);
+    MoveList moveGen(board);
+    moveGen.generateAllMoves(board);
+    ASSERT_EQ(moveGen.moves.size(), 20);
 }
 
 TEST_F(MoveGenTest, perftStartpos) {


### PR DESCRIPTION
Most moves that are generated are not used due to pruning, so it's more efficient to dynamically generate stages of moves depending on the need. As a result of designing an entirely new move generation, there are some changes to move ordering with captures, which also affects quiescent search:
* Captures scoring correctly handles en-passant
* Promotions to queens are counted as captures

H1 of 5 elo was used to get more games to test that this moveGen doesn't crash.

```
Advancement Test:
Time Control: 10s + 0.1s
Games: N=311 W=192 L=47 D=72
Elo:  175.5 +/- 36.8
Bench: 4944366

Alpha: 0.05
Beta: 0.05
Elo0: 0
Elo1: 5
H1 was accepted
```
