### PR TITLE
Mop up evaluation

### DIFF
--- a/src/board.cpp
+++ b/src/board.cpp
@@ -396,7 +396,7 @@ bool Board::isLegalMove(const BoardMove move) const {
     
 // positive return values means winning for the side to move, negative is opposite
 int Board::evaluate() const {
-    int rawEval = this->eval.getRawEval();
+    int rawEval = this->eval.getRawEval(this->pieceSets);
     return this->isWhiteTurn ? rawEval : rawEval * -1;
 }
 

--- a/src/board.hpp
+++ b/src/board.hpp
@@ -42,7 +42,7 @@ struct Board {
     friend bool operator==(const Board& lhs, const Board& rhs);
     friend std::ostream& operator<<(std::ostream& os, const Board& target);
 
-    std::array<uint64_t, NUM_BITBOARDS> pieceSets = {0ull};
+    PieceSets pieceSets = {0ull};
     std::array<pieceTypes, BOARD_SIZE> board = {EmptyPiece};
 
     uint64_t zobristKey; // zobristKeyHistory also contains zobristKey
@@ -58,4 +58,4 @@ struct Board {
 };
 
 castleRights castleRightsBit(Square finalKingPos, bool isWhiteTurn);
-bool currKingInAttack(const std::array<uint64_t, NUM_BITBOARDS>& pieceSets, bool isWhiteTurn);
+bool currKingInAttack(const PieceSets& pieceSets, bool isWhiteTurn);

--- a/src/eval.hpp
+++ b/src/eval.hpp
@@ -9,9 +9,11 @@ constexpr int totalPhase = 24;
 
 struct Info {
     Info() = default;
-    int getRawEval() const;
+    int getRawEval(const PieceSets& pieceSets) const;
     void addPiece(Square square, pieceTypes piece);
     void removePiece(Square square, pieceTypes piece);
+
+    int mopUpScore(const PieceSets& pieceSets, int score) const;
 
     int opScore = 0;
     int egScore = 0;

--- a/src/types.hpp
+++ b/src/types.hpp
@@ -5,6 +5,7 @@
 #include <unordered_map>
 
 #define Square uint8_t
+#define PieceSets std::array<uint64_t, NUM_BITBOARDS>
 
 constexpr int BOARD_SIZE = 64;
 constexpr int NUM_BITBOARDS = 14;


### PR DESCRIPTION
This adds a score to make winning kings approach the enemy king when there is a basic endgame checkmate position on the board like King + Rook vs King. This makes up for deficiencies of the Piece-Square Tables.

```
Advancement Test:
Time Control: 10s + 0.1s
Games: N=18630 W=6675 L=6392 D=5563
Elo:  5.3 +/- 4.2
Bench: 4944366

Alpha: 0.05
Beta: 0.05
Elo0: 0
Elo1: 5
H1 was accepted
```
