### PR TITLE
Late Move Reductions (LMR)

### DIFF
--- a/src/moveOrder.cpp
+++ b/src/moveOrder.cpp
@@ -69,6 +69,10 @@ int MovePicker::getMovesPicked() const {
     return this->movesPicked;
 }
 
+bool MovePicker::stagesLeft() const {
+    return this->stage != Stage::None;
+}
+
 // Due to pruning, we don't need to sort the entire array of moves for move ordering.
 // When sorting only small portions of arrays, using partial insertion sort is faster.
 BoardMove MovePicker::pickMove() {

--- a/src/moveOrder.hpp
+++ b/src/moveOrder.hpp
@@ -18,6 +18,7 @@ class MovePicker {
         MovePicker(const Board& board, Stage a_stage, BoardMove a_TTMove = BoardMove());
         bool movesLeft(const Board& board);
         int getMovesPicked() const;
+        bool stagesLeft() const;
         BoardMove pickMove();
     private:
         enum MoveScores {

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -121,19 +121,37 @@ int Searcher::search(int alpha, int beta, int depth, int distanceFromRoot) {
 
     // start search through moves
     int bestscore = MIN_ALPHA;
-    BoardMove bestMove;
+    BoardMove bestMove, move;
+    bool LMRFailed, doFullSearch;
     while (movePicker.movesLeft(board)) {
-        BoardMove move = movePicker.pickMove();
-        /*************
-         * Principle Variation Search:
-        **************/
+        move = movePicker.pickMove();
         board.makeMove(move);
-        if (ISPV && movePicker.getMovesPicked() == 1) {
-            score = -search<PV>(-beta, -alpha, depth - 1, distanceFromRoot + 1);
+        /*************
+         * Late Move Reductions (LMR):
+         * Search moves that are likely to be less good to lower depths with null bounds
+         * Researches will happen with LMR fails
+        **************/
+        if (!movePicker.stagesLeft() // don't reduce captures
+            && movePicker.getMovesPicked() >= 4 
+            && depth >= 3) {
+            
+            int reductionDepth = depth - 2;
+            score = -search<NOTPV>(-alpha - 1, -alpha, reductionDepth, distanceFromRoot + 1);
+            LMRFailed = score > alpha;
         } else {
+            LMRFailed = !ISPV || movePicker.getMovesPicked() == 0;
+        }
+        /*************
+         * Principle Variation Search (PVS):
+         * Only search PV moves with full bounds, with other moves with null bounds
+         * Research null bound searches if they fail
+        **************/
+        if (LMRFailed) {
             score = -search<NOTPV>(-alpha - 1, -alpha, depth - 1, distanceFromRoot + 1);
-            if (score > alpha && score < beta)
-                score = -search<PV>(-beta, -alpha, depth - 1, distanceFromRoot + 1);
+        }
+        doFullSearch = ISPV && ((score > alpha && score < beta) || movePicker.getMovesPicked() == 1);
+        if (doFullSearch) {
+            score = -search<PV>(-beta, -alpha, depth - 1, distanceFromRoot + 1);
         }
         board.undoMove(); 
 


### PR DESCRIPTION
Moves that are searched later are more likely to not need full searches, meaning that their depths can be reduced. This is an implementation of the most basic form of LMR possible,  and in the future, enhancements such as using the log formula can be considered.

```
Advancement Test:
Time Control: 10s + 0.1s
Games: N=1392 W=527 L=436 D=429
Elo: 22.7 +/- 15.2
Bench: 1172276

Alpha: 0.05
Beta: 0.05
Elo0: 0
Elo1: 10
H1 was accepted
```
