### PR TITLE
Killer Moves

### DIFF
--- a/src/moveOrder.cpp
+++ b/src/moveOrder.cpp
@@ -9,10 +9,11 @@
 
 namespace MoveOrder {
 
-MovePicker::MovePicker(const Board& board, Stage a_stage, BoardMove a_TTMove) {
+MovePicker::MovePicker(const Board& board, Stage a_stage, BoardMove a_TTMove, BoardMove a_killerMove) {
     this->moveList = MoveList(board);
     this->moveScores = std::array<int, MAX_MOVES>{};
     this->TTMove = a_TTMove;
+    this->killerMove = a_killerMove;
     this->movesPicked = 0;
 
     if (board.moveIsCapture(this->TTMove)) {
@@ -48,6 +49,9 @@ void MovePicker::assignMoveScores(const Board& board) {
             const int victimValue = this->getVictimScore(board, move);
             const int attackerValue = pieceValues[board.getPiece(move.sqr1())];
             this->moveScores[i] = MoveScores::Capture + victimValue - attackerValue;
+        }
+        else if (move == this->killerMove) {
+            this->moveScores[i] = MoveScores::Killer;
         }
         else {
             this->moveScores[i] = MoveScores::Quiet;

--- a/src/moveOrder.hpp
+++ b/src/moveOrder.hpp
@@ -15,15 +15,16 @@ enum Stage {
 
 class MovePicker {
     public:
-        MovePicker(const Board& board, Stage a_stage, BoardMove a_TTMove = BoardMove());
+        MovePicker(const Board& board, Stage a_stage, BoardMove a_TTMove = BoardMove(), BoardMove a_killerMove = BoardMove());
         bool movesLeft(const Board& board);
         int getMovesPicked() const;
         bool stagesLeft() const;
         BoardMove pickMove();
     private:
         enum MoveScores {
-            PV = 1 << 20,
-            Capture = 1 << 10,
+            PV = 1 << 30,
+            Capture = 1 << 25,
+            Killer = 1 << 20,
             Quiet = 0,
         };
 
@@ -34,7 +35,7 @@ class MovePicker {
         MoveList moveList;
         std::array<int, MAX_MOVES> moveScores;
         Stage stage;
-        BoardMove TTMove;
+        BoardMove TTMove, killerMove;
         unsigned int movesPicked;
 };
 

--- a/src/search.hpp
+++ b/src/search.hpp
@@ -25,6 +25,10 @@ struct Info {
     uint64_t timeElapsed{};
 };
 
+struct StackEntry {
+    int distanceFromRoot;
+};
+
 class Searcher {
     public:  
         Searcher(Board a_board, Timeman::TimeManager a_tm, int depthLimit) {
@@ -37,8 +41,8 @@ class Searcher {
         Info startThinking();
 
         template <NodeTypes NODE>
-        int search(int alpha, int beta, int depth, int distanceFromRoot);
-        int quiesce(int alpha, int beta, int depth, int distanceFromRoot);
+        int search(int alpha, int beta, int depth, StackEntry* ss);
+        int quiesce(int alpha, int beta, int depth, StackEntry* ss);
         void storeInTT(TTable::Entry entry, int eval, BoardMove move, int depth) const;
 
         void outputUciInfo(Info searchResult) const;
@@ -50,6 +54,7 @@ class Searcher {
         int max_seldepth;
         BoardMove finalMove;
 
+        std::array<StackEntry, MAX_PLY> stack;
         Timeman::TimeManager tm;
         int depth_limit;
         bool printInfo = true;

--- a/src/search.hpp
+++ b/src/search.hpp
@@ -26,7 +26,8 @@ struct Info {
 };
 
 struct StackEntry {
-    int distanceFromRoot;
+    BoardMove killerMove{};
+    int distanceFromRoot{};
 };
 
 class Searcher {

--- a/src/types.hpp
+++ b/src/types.hpp
@@ -9,6 +9,7 @@ constexpr int NUM_BITBOARDS = 14;
 constexpr int NUM_COLORED_PIECES = 12;
 constexpr int NUM_PIECES = 6;
 constexpr int MAX_MOVES = 256;
+constexpr int MAX_PLY = 250;
 
 using Square = uint8_t;
 using PieceSets = std::array<uint64_t, NUM_BITBOARDS>;


### PR DESCRIPTION
Killer moves are quiet moves that cause beta cutoffs in sibling nodes. Killer moves are sorted above normal quiet moves.

```
Advancement Test:
Time Control: 10s + 0.1s
Games: N=645 W=246 L=171 D=228
Elo: 40.6 +/- 21.6
Bench: 7658778

Alpha: 0.05
Beta: 0.05
Elo0: 0
Elo1: 10
H1 was accepted
```
