### PR TITLE
Tweak MVV-LVA + don't depth-limit quiescence

### DIFF
--- a/src/moveOrder.cpp
+++ b/src/moveOrder.cpp
@@ -46,7 +46,7 @@ void MovePicker::assignMoveScores(const Board& board) {
             this->moveScores[i] = MoveScores::PV;
         }
         else if (ASSIGN_CAPTURES && board.moveIsCapture(move)) {
-            const int victimValue = this->getVictimScore(board, move);
+            const int victimValue = this->getVictimScore(board, move) << 8;
             const int attackerValue = pieceValues[board.getPiece(move.sqr1())];
             this->moveScores[i] = MoveScores::Capture + victimValue - attackerValue;
         }

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -87,7 +87,7 @@ int Searcher::search(int alpha, int beta, int depth, StackEntry* ss) {
     }
     // max depth reached
     if (depth <= 0) {
-        return quiesce(alpha, beta, 6, ss);
+        return quiesce(alpha, beta, ss);
     }
 
     /************
@@ -203,7 +203,7 @@ int Searcher::search(int alpha, int beta, int depth, StackEntry* ss) {
     return bestscore;
 }
 
-int Searcher::quiesce(int alpha, int beta, int depth, StackEntry* ss) {
+int Searcher::quiesce(int alpha, int beta, StackEntry* ss) {
     if(this->tm.hardTimeUp()) {
         return 0;
     }
@@ -216,15 +216,13 @@ int Searcher::quiesce(int alpha, int beta, int depth, StackEntry* ss) {
         return beta;
     if(alpha < stand_pat)
         alpha = stand_pat;
-    if(depth == 0)
-        return stand_pat;
 
     MoveOrder::MovePicker movePicker(board, MoveOrder::Captures);
     int score = MIN_ALPHA;
     while (movePicker.movesLeft(board)) {
         BoardMove move = movePicker.pickMove();
         board.makeMove(move);
-        score = -quiesce(-beta, -alpha, depth - 1, ss + 1);
+        score = -quiesce(-beta, -alpha, ss + 1);
         board.undoMove(); 
 
         if(score >= beta)

--- a/src/search.hpp
+++ b/src/search.hpp
@@ -43,7 +43,7 @@ class Searcher {
 
         template <NodeTypes NODE>
         int search(int alpha, int beta, int depth, StackEntry* ss);
-        int quiesce(int alpha, int beta, int depth, StackEntry* ss);
+        int quiesce(int alpha, int beta, StackEntry* ss);
         void storeInTT(TTable::Entry entry, int eval, BoardMove move, int depth) const;
 
         void outputUciInfo(Info searchResult) const;


### PR DESCRIPTION
For MVV-LVA, an extra bonus was given to victim scores so that the most valuable victims are searched fully before moving onto the next ones. This lowered bench somewhat, but previous attempts at using the formula showed negligible change. This is where the unlimited quiescence came in, as deeper quiescence had failed previously without the tweaked MVV-LVA formula.

```
Advancement Test:
Time Control: 10s + 0.1s
Games: N=1387 W=483 L=398 D=504
Elo: 21.3 +/- 14.6
Bench: 8243970

Alpha: 0.05
Beta: 0.05
Elo0: 0
Elo1: 10
H1 was accepted
```
