### PR TITLE
Don't check system time every node

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -69,7 +69,7 @@ int Searcher::search(int alpha, int beta, int depth, StackEntry* ss) {
     const int oldAlpha = alpha;
 
     // time up
-    if (this->tm.hardTimeUp()) {
+    if (this->stopSearching()) {
         return NO_SCORE;
     }
 
@@ -165,7 +165,7 @@ int Searcher::search(int alpha, int beta, int depth, StackEntry* ss) {
         board.undoMove(); 
 
         // don't update best move if time is up
-        if (this->tm.hardTimeUp()) {
+        if (this->stopSearching()) {
             return bestscore;
         }
         
@@ -204,8 +204,8 @@ int Searcher::search(int alpha, int beta, int depth, StackEntry* ss) {
 }
 
 int Searcher::quiesce(int alpha, int beta, StackEntry* ss) {
-    if(this->tm.hardTimeUp()) {
-        return 0;
+    if (this->stopSearching()) {
+        return NO_SCORE;
     }
 
     ++this->nodes;
@@ -251,6 +251,14 @@ void Searcher::storeInTT(TTable::Entry entry, int eval, BoardMove move, int dept
             entry.move = move;
             TTable::table.storeEntry(entry.key, entry);
     }
+}
+
+bool Searcher::stopSearching() {
+    // only check system time every 1024 nodes for performance
+    if (this->nodes % 1024 == 0 && !this->stopSearchFlag) {
+        this->stopSearchFlag = this->tm.hardTimeUp();
+    }
+    return this->stopSearchFlag;
 }
 
 void Searcher::outputUciInfo(Info searchResult) const {

--- a/src/search.hpp
+++ b/src/search.hpp
@@ -40,16 +40,15 @@ class Searcher {
             this->depth_limit = depthLimit;
         };
         Info startThinking();
-
+        void setPrintInfo(bool flag) {this->printInfo = flag;};
+    private:
         template <NodeTypes NODE>
         int search(int alpha, int beta, int depth, StackEntry* ss);
         int quiesce(int alpha, int beta, StackEntry* ss);
         void storeInTT(TTable::Entry entry, int eval, BoardMove move, int depth) const;
-
+        bool stopSearching();
         void outputUciInfo(Info searchResult) const;
-        void setPrintInfo(bool flag) {this->printInfo = flag;}; 
 
-    private:
         Board board;
         uint64_t nodes;
         int max_seldepth;
@@ -59,6 +58,7 @@ class Searcher {
         Timeman::TimeManager tm;
         int depth_limit;
         bool printInfo = true;
+        bool stopSearchFlag = false;
 };
 
 } // namespace Search

--- a/src/timeman.hpp
+++ b/src/timeman.hpp
@@ -7,16 +7,18 @@ namespace Timeman {
 
 constexpr uint64_t INF_TIME = 1 << 28;
 
-struct TimeManager
+class TimeManager
 {
-    TimeManager() : TimeManager(INF_TIME, 0){};
-    TimeManager(uint64_t time, uint64_t inc);
-    bool hardTimeUp() const;
-    bool softTimeUp() const;
-    int64_t getTimeElapsed() const;
-    
-    std::chrono::system_clock::time_point startTime; 
-    int64_t hardTimeLimit, softTimeLimit;
+    public:
+        TimeManager() : TimeManager(INF_TIME, 0){};
+        TimeManager(uint64_t time, uint64_t inc);
+        bool hardTimeUp() const;
+        bool softTimeUp() const;
+        int64_t getTimeElapsed() const;
+
+    private:
+        std::chrono::system_clock::time_point startTime;
+        int64_t hardTimeLimit, softTimeLimit;
 };
 
 } // namespace Timeman


### PR DESCRIPTION
This checks system time every 1024 nodes instead, which helps with performance.

```
Advancement Test:
Time Control: 10s + 0.1s
Games: N=1044 W=385 L=302 D=357
Elo: 27.7 +/- 17.1
Bench: 8243970

Alpha: 0.05
Beta: 0.05
Elo0: 0
Elo1: 10
H1 was accepted
```