### PR TITLE
Aspiration Search

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -81,17 +81,17 @@ int Searcher::aspiration(int depth, int prevEval) {
     while (true) {
         result = this->search<ROOT>(alpha, beta, depth, &this->stack[0]);
 
-        if (this->tm.hardTimeUp()) {
+        if (this->stopSearching()) {
             break;
         }
 
         // adjust bounds if the result was outside of them
         if (result <= alpha && alpha != MIN_ALPHA) {
             alpha = std::max(alpha - delta, MIN_ALPHA);
-            delta += delta / 2;
+            delta *= 2;
         } else if (result >= beta && beta != MAX_BETA) {
             beta = std::min(beta + delta, MAX_BETA);
-            delta += delta / 2;
+            delta *= 2;
         } else {
             break;
         }

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -81,11 +81,15 @@ int Searcher::aspiration(int depth, int prevEval) {
     while (true) {
         result = this->search<ROOT>(alpha, beta, depth, &this->stack[0]);
 
+        if (this->tm.hardTimeUp()) {
+            break;
+        }
+
         // adjust bounds if the result was outside of them
-        if (result <= alpha) {
+        if (result <= alpha && alpha != MIN_ALPHA) {
             alpha = std::max(alpha - delta, MIN_ALPHA);
             delta += delta / 2;
-        } else if (result >= beta) {
+        } else if (result >= beta && beta != MAX_BETA) {
             beta = std::min(beta + delta, MAX_BETA);
             delta += delta / 2;
         } else {

--- a/src/search.hpp
+++ b/src/search.hpp
@@ -42,6 +42,7 @@ class Searcher {
         Info startThinking();
         void setPrintInfo(bool flag) {this->printInfo = flag;};
     private:
+        int aspiration(int depth, int prevEval);
         template <NodeTypes NODE>
         int search(int alpha, int beta, int depth, StackEntry* ss);
         int quiesce(int alpha, int beta, StackEntry* ss);


### PR DESCRIPTION
By aspiring to search with non-full bounds, search times can be reduced. Theoretically speaking, researches don't need to widen both alpha and beta, so that behavior will be tested soon.

```
Advancement Test:
Time Control: 10s + 0.1s
Games: N=855 W=307 L=230 D=318
307 - 230 - 318
Elo: 31.4 +/- 18.5
Bench: 7867016

Alpha: 0.05
Beta: 0.05
Elo0: 0
Elo1: 10
H1 was accepted
```