### PR TITLE
Butterfly History Tables

### DIFF
--- a/src/moveOrder.hpp
+++ b/src/moveOrder.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <array>
 #include <vector>
 
 #include "moveGen.hpp"
@@ -8,6 +9,9 @@
 #include "types.hpp"
 
 namespace MoveOrder { 
+
+// a butterfly history heuristic table
+extern HistoryTable History;
 
 enum Stage {
     None = 0, Captures = 0b01, Quiets = 0b10, All = Captures | Quiets
@@ -42,5 +46,7 @@ class MovePicker {
 constexpr inline Stage operator&(Stage lhs, Stage rhs) {
     return static_cast<Stage>(static_cast<int>(lhs) & static_cast<int>(rhs));
 }
+
+void clearHistory();
 
 } // namespace MoveOrder

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -223,7 +223,7 @@ int Searcher::search(int alpha, int beta, int depth, StackEntry* ss) {
 
                 // prune if a move is too good, opponent will avoid playing into this node
                 if (score >= beta) {
-                    MoveOrder::History[move.sqr1()][move.sqr2()] += depth * depth;
+                    MoveOrder::History[move.sqr1()][move.sqr2()] += depth * (depth - 1);
                     if (quietMove) {
                         ss->killerMove = move;
                     }

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -126,8 +126,8 @@ int Searcher::search(int alpha, int beta, int depth, StackEntry* ss) {
     *************/
     BoardMove TTMove;
     TTable::Entry entry;
-    if (TTable::table.entryExists(this->board.zobristKey)) {
-        entry = TTable::table.getEntry(this->board.zobristKey);
+    if (TTable::Table.entryExists(this->board.zobristKey)) {
+        entry = TTable::Table.getEntry(this->board.zobristKey);
 
         if (!ISPV && entry.depth >= depth) {
             if (entry.flag == EvalType::EXACT
@@ -160,10 +160,10 @@ int Searcher::search(int alpha, int beta, int depth, StackEntry* ss) {
 
     // start search through moves
     int score, bestscore = MIN_ALPHA;
-    BoardMove bestMove, move;
+    BoardMove bestMove;
     bool doFullNullSearch, doPVS;
     while (movePicker.movesLeft(board)) {
-        move = movePicker.pickMove();
+        const BoardMove move = movePicker.pickMove();
         board.makeMove(move);
         const bool moveGivesCheck = currKingInAttack(this->board.pieceSets, this->board.isWhiteTurn);
         const bool quietMove = !movePicker.stagesLeft();
@@ -223,6 +223,7 @@ int Searcher::search(int alpha, int beta, int depth, StackEntry* ss) {
 
                 // prune if a move is too good, opponent will avoid playing into this node
                 if (score >= beta) {
+                    MoveOrder::History[move.sqr1()][move.sqr2()] += depth * depth;
                     if (quietMove) {
                         ss->killerMove = move;
                     }
@@ -239,9 +240,11 @@ int Searcher::search(int alpha, int beta, int depth, StackEntry* ss) {
         return DRAW_SCORE;
     }
 
-    // A search for this depth is complete with a best move, so it can be stored in the transposition table
-    entry.flag = (bestscore >= beta) ? EvalType::LOWER : (alpha == oldAlpha) ? EvalType::UPPER : EvalType::EXACT;
-    this->storeInTT(entry, bestscore, bestMove, depth);
+    // store results with best moves in transposition table
+    if (bestMove) {
+        entry.flag = (bestscore >= beta) ? EvalType::LOWER : (alpha == oldAlpha) ? EvalType::UPPER : EvalType::EXACT;
+        this->storeInTT(entry, bestscore, bestMove, depth);
+    }
     return bestscore;
 }
 
@@ -284,14 +287,13 @@ void Searcher::storeInTT(TTable::Entry entry, int eval, BoardMove move, int dept
     in hash are preserved in the table since there can be repeated boards, but replacing entries
     with moves from more modern roots is better
     */
-    if ( (depth >= entry.depth || this->board.age >= entry.age)
-        && move) {
+    if (depth >= entry.depth || this->board.age >= entry.age) {
             entry.key = this->board.zobristKey;
             entry.age = this->board.age;
             entry.depth = depth;
             entry.eval = eval;
             entry.move = move;
-            TTable::table.storeEntry(entry.key, entry);
+            TTable::Table.storeEntry(entry.key, entry);
     }
 }
 
@@ -321,7 +323,7 @@ void Searcher::outputUciInfo(Info searchResult) const {
     } else {
         std::cout << "score mate " << searchResult.mateIn << ' ';
     }
-    std::cout << "hashfull " << TTable::table.hashFull() << ' ';
+    std::cout << "hashfull " << TTable::Table.hashFull() << ' ';
     std::cout << std::endl;
 
 }

--- a/src/ttable.cpp
+++ b/src/ttable.cpp
@@ -9,7 +9,7 @@
 namespace TTable {
 
 // global definition
-TTable table = TTable();
+TTable Table = TTable();
 
 void TTable::resize(int sizeMb) {
     // sizeof uses bytes and not megabytes

--- a/src/ttable.hpp
+++ b/src/ttable.hpp
@@ -36,6 +36,6 @@ class TTable {
 };
 
 // global declaration
-extern TTable table;
+extern TTable Table;
 
 } // namespace TTable

--- a/src/types.hpp
+++ b/src/types.hpp
@@ -13,6 +13,7 @@ constexpr int MAX_PLY = 250;
 
 using Square = uint8_t;
 using PieceSets = std::array<uint64_t, NUM_BITBOARDS>;
+using HistoryTable = std::array<std::array<uint64_t, BOARD_SIZE>, BOARD_SIZE>;
 
 enum pieceTypes {EmptyPiece = -1,
                 WKing, WQueen, WBishop, WKnight, WRook, WPawn, 

--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -11,6 +11,7 @@
 #include "timeman.hpp"
 #include "ttable.hpp"
 #include "search.hpp"
+#include "moveOrder.hpp"
 #include "moveGen.hpp"
 #include "board.hpp"
 
@@ -80,12 +81,13 @@ void setOption(std::istringstream& input){
         OPTIONS.depth = std::stoi(value);
     }
     else if (id == "hash") {
-        TTable::table.resize(std::stoi(value));
+        TTable::Table.resize(std::stoi(value));
     }
 }
 
 void uciNewGame() {
-    TTable::table.clear();
+    TTable::Table.clear();
+    MoveOrder::clearHistory();
 }
 
 Board position(std::istringstream& input) {


### PR DESCRIPTION
Typically known as a generalization of killer moves, all beta cutoffs are used to order quiets that are not killers.

```
Advancement Test:
Time Control: 10s + 0.1s
Games: N=1989 W=622 L=534 D=833
Elo: 15.4 +/- 11.6
Bench: 7446026

Alpha: 0.05
Beta: 0.05
Elo0: 0
Elo1: 10
```