### PR TITLE
Reverse Futility Pruning

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -125,6 +125,7 @@ int Searcher::search(int alpha, int beta, int depth, StackEntry* ss) {
      * Probe Tranposition Table
     *************/
     BoardMove TTMove;
+    int staticEval;
     TTable::Entry entry;
     if (TTable::Table.entryExists(this->board.zobristKey)) {
         entry = TTable::Table.getEntry(this->board.zobristKey);
@@ -138,6 +139,17 @@ int Searcher::search(int alpha, int beta, int depth, StackEntry* ss) {
         }
 
         TTMove = entry.move;
+        staticEval = entry.eval;
+    } else {
+        staticEval = this->board.evaluate();
+    }
+
+    /************
+     * Reverse Futility Pruning
+     * If the evaluation is too far above beta, assume that there is no chance for the opponent to catch up
+    *************/
+    if (!ISPV && depth < 5 && staticEval - (100 * depth) >= beta) {
+        return beta;
     }
 
     const bool inCheck = currKingInAttack(this->board.pieceSets, this->board.isWhiteTurn);


### PR DESCRIPTION
Reverse Futility Pruning prunes statically evaluated positions that are deemed to good for the opponent to catch up with.

```
Advancement Test:
Time Control: 10s + 0.1s
Games: N=418 W=165 L=96 D=157
Elo: 57.9 +/- 26.5
Bench: 4081690

Alpha: 0.05
Beta: 0.05
Elo0: 0
Elo1: 10
```
