### PR TITLE
Log LMR Formula

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,8 +1,10 @@
 #include "uci.hpp"
+#include "search.hpp"
 #include "attacks.hpp"
 
 int main() {
     Attacks::init();
+    Search::initLMRTable();
 
     Uci::printEngineInfo();
     Uci::setOptionLoop();

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -14,11 +14,11 @@
 namespace Search {
 
 std::array<std::array<int, MAX_MOVES>, MAX_DEPTH> LMRTable{};
-
 void initLMRTable() {
-    for (int depth = 0; depth < MAX_DEPTH; ++depth) {
-        for (int moves = 0; moves < MAX_MOVES; ++moves) {
-            LMRTable[depth][moves] = static_cast<int>(1.0 + std::log(depth) * std::log(moves) / 2.0);
+    for (int depth = 1; depth < MAX_DEPTH; ++depth) {
+        for (int moves = 1; moves < MAX_MOVES; ++moves) {
+            LMRTable[depth][moves] = static_cast<int>(2.0 + std::log(depth) * std::log(moves) / 1.50);
+            LMRTable[depth][moves] = std::clamp(LMRTable[depth][moves], 0, depth - 2);
         }
     }
 }

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -13,6 +13,16 @@
 
 namespace Search {
 
+std::array<std::array<int, MAX_MOVES>, MAX_DEPTH> LMRTable{};
+
+void initLMRTable() {
+    for (int depth = 0; depth < MAX_DEPTH; ++depth) {
+        for (int moves = 0; moves < MAX_MOVES; ++moves) {
+            LMRTable[depth][moves] = static_cast<int>(1.0 + std::log(depth) * std::log(moves) / 2.0);
+        }
+    }
+}
+
 Info Searcher::startThinking() {
     Info result;
 
@@ -201,7 +211,8 @@ int Searcher::search(int alpha, int beta, int depth, StackEntry* ss) {
             && depth >= 3
             && !moveGivesCheck) {
             
-            score = -search<NOTPV>(-alpha - 1, -alpha, newDepth - 2, ss + 1);
+            int reductionDepth = LMRTable[depth][movePicker.getMovesPicked()];
+            score = -search<NOTPV>(-alpha - 1, -alpha, reductionDepth, ss + 1);
             doFullNullSearch = score > alpha;
         } else {
             doFullNullSearch = !ISPV || movePicker.getMovesPicked() > 1;

--- a/src/search.hpp
+++ b/src/search.hpp
@@ -1,6 +1,5 @@
 #pragma once
 
-#include <cmath>
 #include <cstdint>
 
 #include "board.hpp"

--- a/src/search.hpp
+++ b/src/search.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <cmath>
 #include <cstdint>
 
 #include "board.hpp"
@@ -14,6 +15,8 @@ constexpr int DRAW_SCORE = 0;
 constexpr int INF_SCORE = 1000000;
 constexpr int MATE_IN_SCORE = INF_SCORE - MAX_PLY;
 constexpr int NO_SCORE = -100000000;
+
+void initLMRTable();
 
 // used for outside UCI representation    
 struct Info {

--- a/src/types.hpp
+++ b/src/types.hpp
@@ -10,6 +10,7 @@ constexpr int NUM_RANKS = 8;
 constexpr int NUM_BITBOARDS = 14;
 constexpr int NUM_COLORED_PIECES = 12;
 constexpr int NUM_PIECES = 6;
+constexpr int MAX_DEPTH = 200;
 constexpr int MAX_MOVES = 256;
 constexpr int MAX_PLY = 250;
 

--- a/src/types.hpp
+++ b/src/types.hpp
@@ -10,7 +10,6 @@ constexpr int NUM_RANKS = 8;
 constexpr int NUM_BITBOARDS = 14;
 constexpr int NUM_COLORED_PIECES = 12;
 constexpr int NUM_PIECES = 6;
-constexpr int MAX_DEPTH = 200;
 constexpr int MAX_MOVES = 256;
 constexpr int MAX_PLY = 250;
 


### PR DESCRIPTION
Instead of doing a fixed depth for late move reductions, reduce based on how late the moves are, as worse quiets tend to be ordered further in the back. 

```
Advancement Test:
Time Control: 10s + 0.1s
Games: N=3180 W=924 L=832 D=1434
Elo: 11.1 +/- 8.9
Bench: 3633988

Alpha: 0.05
Beta: 0.05
Elo0: 0
Elo1: 10
```