### PR TITLE
Used fixed size arrays instead of vectors for movegen

### DIFF
--- a/src/moveGen.hpp
+++ b/src/moveGen.hpp
@@ -15,7 +15,7 @@ class MoveList {
         void generateCaptures(const Board& board);
         void generateQuiets(const Board& board);
 
-        std::vector<BoardMove> moves{};
+        FixedVector<BoardMove, MAX_MOVES> moves{};
     private:
         template<typename Func>
         void generatePieceMoves(uint64_t pieces, uint64_t validDests, Func pieceMoves, const Board& board);

--- a/src/types.hpp
+++ b/src/types.hpp
@@ -90,3 +90,28 @@ constexpr inline castleRights& operator&=(castleRights& lhs, castleRights rhs) {
 constexpr inline castleRights& operator^=(castleRights& lhs, castleRights rhs) {
     return lhs = lhs ^ rhs;
 }
+
+// internally uses a fixed size array to avoid memory reallocations, like what can happen in std::vector
+template<typename T, std::size_t N>
+class FixedVector {
+    public:
+        constexpr T& operator[](int index) {
+            return this->container[index];
+        }
+        constexpr void push_back(const T& entry) {
+            this->container[this->vecSize] = entry;
+            this->vecSize++;
+        }
+        constexpr auto begin() const {
+            return this->container.begin();
+        }
+        constexpr auto end() const {
+            return this->container.begin() + this->vecSize;
+        }
+        constexpr auto size() const {
+            return this->vecSize;
+        }
+    private:
+        std::array<T, N> container{};
+        std::size_t vecSize{};
+};


### PR DESCRIPTION
```
Advancement Test:
Time Control: 10s + 0.1s
Games: N=447 W=167 L=100 D=180
Elo: 52.5 +/- 25.0
Bench: 3495283

Alpha: 0.05
Beta: 0.05
Elo0: 0
Elo1: 10
```
