### PR TITLE
Refactor Transposition Table

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -297,7 +297,7 @@ int Searcher::search(int alpha, int beta, int depth, StackEntry* ss) {
     // store results with best moves in transposition table
     if (bestMove) {
         entry.flag = (bestscore >= beta) ? EvalType::LOWER : (alpha == oldAlpha) ? EvalType::UPPER : EvalType::EXACT;
-        this->storeInTT(entry, bestscore, bestMove, depth);
+        TTable::Table.store(entry, bestscore, bestMove, depth, this->board.age, this->board.zobristKey);
     }
     return bestscore;
 }
@@ -333,23 +333,6 @@ int Searcher::quiesce(int alpha, int beta, StackEntry* ss) {
 
 }
 
-void Searcher::storeInTT(TTable::Entry entry, int eval, BoardMove move, int depth) const {
-    /* entries in the transposition table are overwritten under two conditions:
-    1. The current search depth is greater than the entry's depth, meaning that a better
-    search has been performed 
-    2. The age of the current position is greater than the previous age. Previous move searches
-    in hash are preserved in the table since there can be repeated boards, but replacing entries
-    with moves from more modern roots is better
-    */
-    if (depth >= entry.depth || this->board.age >= entry.age) {
-            entry.key = this->board.zobristKey;
-            entry.age = this->board.age;
-            entry.depth = depth;
-            entry.eval = eval;
-            entry.move = move;
-            TTable::Table.storeEntry(entry.key, entry);
-    }
-}
 
 bool Searcher::stopSearching() {
     // only check system time every 1024 nodes for performance

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -155,14 +155,13 @@ int Searcher::search(int alpha, int beta, int depth, StackEntry* ss) {
     *************/
     BoardMove TTMove;
     int staticEval;
-    TTable::Entry entry;
     if (TTable::Table.entryExists(this->board.zobristKey)) {
-        entry = TTable::Table.getEntry(this->board.zobristKey);
+        const TTable::Entry entry = TTable::Table.getEntry(this->board.zobristKey);
 
         if (!ISPV && entry.depth >= depth) {
-            if (entry.flag == EvalType::EXACT
-                || (entry.flag == EvalType::UPPER && entry.eval <= alpha)
-                || (entry.flag == EvalType::LOWER && entry.eval >= beta)) {
+            if (entry.bound == EvalType::EXACT
+                || (entry.bound == EvalType::UPPER && entry.eval <= alpha)
+                || (entry.bound == EvalType::LOWER && entry.eval >= beta)) {
                 return entry.eval;
             }
         }
@@ -296,8 +295,8 @@ int Searcher::search(int alpha, int beta, int depth, StackEntry* ss) {
 
     // store results with best moves in transposition table
     if (bestMove) {
-        entry.flag = (bestscore >= beta) ? EvalType::LOWER : (alpha == oldAlpha) ? EvalType::UPPER : EvalType::EXACT;
-        TTable::Table.store(entry, bestscore, bestMove, depth, this->board.age, this->board.zobristKey);
+        const EvalType bound = (bestscore >= beta) ? EvalType::LOWER : (alpha == oldAlpha) ? EvalType::UPPER : EvalType::EXACT;
+        TTable::Table.store(bestscore, bestMove, bound, depth, this->board.age, this->board.zobristKey);
     }
     return bestscore;
 }

--- a/src/search.hpp
+++ b/src/search.hpp
@@ -71,7 +71,6 @@ class Searcher {
         template <NodeTypes NODE>
         int search(int alpha, int beta, int depth, StackEntry* ss);
         int quiesce(int alpha, int beta, StackEntry* ss);
-        void storeInTT(TTable::Entry entry, int eval, BoardMove move, int depth) const;
         bool stopSearching();
         void outputUciInfo(Info searchResult) const;
 

--- a/src/ttable.cpp
+++ b/src/ttable.cpp
@@ -68,7 +68,7 @@ void TTable::store(int eval, BoardMove move, EvalType bound, int depth, int age,
     with moves from more modern roots is better
     */
     Entry* entry = &this->table[this->getIndex(key)];
-    if (depth >= entry->depth || age >= entry->age) {
+    if (true) {
         entry->eval = eval;
         entry->move = move;
         entry->bound = bound;

--- a/src/ttable.cpp
+++ b/src/ttable.cpp
@@ -43,7 +43,7 @@ void TTable::clear() {
 int TTable::hashFull() {
     int entriesUsed = 0;
     for (int i = 0; i < 1000; ++i) {
-        if (this->table[i].move != BoardMove()) {
+        if (this->table[i].move) {
             ++entriesUsed;
         }
     }
@@ -59,21 +59,22 @@ Entry TTable::getEntry(uint64_t key) const {
     return this->table[this->getIndex(key)];
 }
 
-void TTable::store(Entry entry, int eval, BoardMove move, int depth, int age, uint64_t key) {
+void TTable::store(int eval, BoardMove move, EvalType bound, int depth, int age, uint64_t key) {
     /* entries in the transposition table are overwritten under two conditions:
     1. The current search depth is greater than the entry's depth, meaning that a better
-    search has been performed 
+    search has been performed
     2. The age of the current position is greater than the previous age. Previous move searches
     in hash are preserved in the table since there can be repeated boards, but replacing entries
     with moves from more modern roots is better
     */
-    if (depth >= entry.depth || age >= entry.age) {
-            entry.key = key;
-            entry.age = age;
-            entry.depth = depth;
-            entry.eval = eval;
-            entry.move = move;
-            this->table[this->getIndex(entry.key)] = entry;
+    Entry* entry = &this->table[this->getIndex(key)];
+    if (depth >= entry->depth || age >= entry->age) {
+        entry->eval = eval;
+        entry->move = move;
+        entry->bound = bound;
+        entry->depth = depth;
+        entry->age = age;
+        entry->key = key;
     }
 }
 

--- a/src/ttable.cpp
+++ b/src/ttable.cpp
@@ -59,8 +59,22 @@ Entry TTable::getEntry(uint64_t key) const {
     return this->table[this->getIndex(key)];
 }
 
-void TTable::storeEntry(uint64_t key, Entry entry) {
-    this->table[this->getIndex(key)] = entry;
+void TTable::store(Entry entry, int eval, BoardMove move, int depth, int age, uint64_t key) {
+    /* entries in the transposition table are overwritten under two conditions:
+    1. The current search depth is greater than the entry's depth, meaning that a better
+    search has been performed 
+    2. The age of the current position is greater than the previous age. Previous move searches
+    in hash are preserved in the table since there can be repeated boards, but replacing entries
+    with moves from more modern roots is better
+    */
+    if (depth >= entry.depth || age >= entry.age) {
+            entry.key = key;
+            entry.age = age;
+            entry.depth = depth;
+            entry.eval = eval;
+            entry.move = move;
+            this->table[this->getIndex(entry.key)] = entry;
+    }
 }
 
 int TTable::getIndex(uint64_t key) const {

--- a/src/ttable.hpp
+++ b/src/ttable.hpp
@@ -33,7 +33,7 @@ struct Entry {
     uint8_t age{};
     int depth{};
     int eval{};
-    EvalType flag = NONE;
+    EvalType bound = NONE;
     BoardMove move{};
 };
 
@@ -46,7 +46,7 @@ class TTable {
 
         bool entryExists(uint64_t key) const;
         Entry getEntry(uint64_t key) const;
-        void store(Entry entry, int eval, BoardMove move, int depth, int age, uint64_t key);
+        void store(int eval, BoardMove move, EvalType bound, int depth, int age, uint64_t key);
     private:
         int getIndex(uint64_t key) const;
         std::vector<Entry> table;

--- a/src/ttable.hpp
+++ b/src/ttable.hpp
@@ -46,9 +46,9 @@ class TTable {
 
         bool entryExists(uint64_t key) const;
         Entry getEntry(uint64_t key) const;
-        void storeEntry(uint64_t key, Entry entry);
-        int getIndex(uint64_t key) const;
+        void store(Entry entry, int eval, BoardMove move, int depth, int age, uint64_t key);
     private:
+        int getIndex(uint64_t key) const;
         std::vector<Entry> table;
         int size;
 };


### PR DESCRIPTION
The replacement strategy was moved to ttable.cpp. The replacement strategy was also changed in that it no longer has wonky behavior, as the old strategy assumed the entry was not replaced between entry access and entry storage. This has been patched with the refactor, so using the old strategy changes bench. Doing always replace keeps the previous bench.

```
Regression Test:
Time Control: 10s + 0.1s
LLR: 2.96 (-2.94, 2.94) [-15.0, 0.0]
Games: N=1672 W=465 L=463 D=744
Elo: 0.4 +/- 24.4
Bench: 3495283
```
