### PR TITLE
History Malus

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -21,7 +21,6 @@
 #include <cassert>
 #include <cmath>
 #include <iostream>
-#include <vector>
 
 #include "search.hpp"
 #include "ttable.hpp"
@@ -30,6 +29,7 @@
 #include "moveGen.hpp"
 #include "board.hpp"
 #include "timeman.hpp"
+#include "utils/fixedVector.hpp"
 
 namespace Search {
 
@@ -209,7 +209,7 @@ int Searcher::search(int alpha, int beta, int depth, StackEntry* ss) {
     // start search through moves
     int score = NO_SCORE, bestscore = -INF_SCORE;
     BoardMove bestMove{};
-    std::vector<BoardMove> failedQuiets{};
+    FixedVector<BoardMove, MAX_MOVES> failedQuiets{};
     bool doFullNullSearch, doPVS;
 
     while (movePicker.movesLeft(this->board, this->history)) {
@@ -289,13 +289,13 @@ int Searcher::search(int alpha, int beta, int depth, StackEntry* ss) {
 
                         // apply malus for quiets that didn't cause beta cutoffs
                         // these quiets were ordered ahead of the cutting move, so they should be penalized
-                        for (const auto& move: failedQuiets) {
-                            this->history[move.sqr1()][move.sqr2()] -= depth * (depth - 1);
+                        for (const auto& quiet: failedQuiets) {
+                            this->history[quiet.sqr1()][quiet.sqr2()] -= depth * (depth - 1);
                         }
                     }
                     break;
                 }
-            } 
+            }
         }
 
         // keep track of all quiets that didn't generate cutoffs

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -296,14 +296,14 @@ int Searcher::search(int alpha, int beta, int depth, StackEntry* ss) {
                     break;
                 }
             } 
-            else {
-                // keep track of quiet moves that don't beat alpha
-                if (quietMove) {
-                    failedQuiets.push_back(move);
-                }
-            }
+        }
+
+        // keep track of all quiets that didn't generate cutoffs
+        if (quietMove) {
+            failedQuiets.push_back(move);
         }
     }
+
     // checkmate or stalemate
     if (movePicker.getMovesPicked() == 0) {
         if (inCheck) {

--- a/src/utils/types.hpp
+++ b/src/utils/types.hpp
@@ -33,7 +33,7 @@ constexpr int MAX_PLY = 250;
 
 using Square = uint8_t;
 using PieceSets = std::array<uint64_t, NUM_BITBOARDS>;
-using HistoryTable = std::array<std::array<uint64_t, BOARD_SIZE>, BOARD_SIZE>;
+using HistoryTable = std::array<std::array<int, BOARD_SIZE>, BOARD_SIZE>;
 using RNGSeed = std::array<uint64_t, 4>;
 
 inline int getFile(Square square) {


### PR DESCRIPTION
Quiet moves that are ordered first due to history but do not end up causing beta cutoffs should be penalized so that better moves can be ordered first more quickly.

```
Advancement Test:
Time Control: 10s + 0.1s
LLR: 2.97 (-2.94, 2.94) [0.0, 10.0]
Games: N=2836 W=794 L=699 D=1343
Elo: 11.6 +/- 9.3
Bench: 2229699
```