### PR TITLE
Only do NMP for high enough static eval

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -188,7 +188,8 @@ int Searcher::search(int alpha, int beta, int depth, StackEntry* ss) {
     *************/
     if (!ISNMP
         && !inCheck
-        && depth >= 2) {
+        && depth >= 2
+        && staticEval >= beta) {
 
         int reduction = 3 + depth / 4;
         board.makeNullMove();


### PR DESCRIPTION
```
Advancement Test:
Time Control: 10s + 0.1s
LLR: 2.98 (-2.94, 2.94) [0.0, 10.0]
Games: N=776 W=236 L=171 D=369
Elo: 29.2 +/- 17.7
Bench: 2249728
```