### PR TITLE
Prefetch TTable entries

### DIFF
--- a/src/ttable.cpp
+++ b/src/ttable.cpp
@@ -78,6 +78,13 @@ void TTable::store(int eval, Move move, EvalType bound, int depth, int age, uint
     }
 }
 
+void TTable::prefetch(uint64_t key) const {
+    if (this->table.empty()) {
+        return;
+    }
+    __builtin_prefetch(&this->table[getIndex(key)]);
+}
+
 int TTable::getIndex(uint64_t key) const {
     return key % this->size;
 }

--- a/src/ttable.hpp
+++ b/src/ttable.hpp
@@ -47,6 +47,7 @@ class TTable {
         bool entryExists(uint64_t key) const;
         Entry getEntry(uint64_t key) const;
         void store(int eval, Move move, EvalType bound, int depth, int age, uint64_t key);
+        void prefetch(uint64_t key) const;
     private:
         int getIndex(uint64_t key) const;
         std::vector<Entry> table;


### PR DESCRIPTION
Transposition table entries will generally not be located in cache due to how large transposition tables can be, so prefetching the entries will give speedups, as lookup times will be reduced.

```
Advancement Test:
Time Control: 10s + 0.1s
LLR: 2.95 (-2.94, 2.94) [0.0, 8.0]
Games: N=3273 W=913 L=808 D=1552
Elo: 11.1 +/- 8.6
Bench:  2249728
```