### PR TITLE
Tempo evaluation

### DIFF
--- a/src/board.cpp
+++ b/src/board.cpp
@@ -417,7 +417,7 @@ bool Board::isDraw() const {
     
 // positive return values means winning for the side to move, negative is opposite
 auto Board::evaluate() -> int {
-    const int rawEval = this->eval.getRawEval(this->pieceSets);
+    const int rawEval = this->eval.getRawEval(this->pieceSets, this->m_isWhiteTurn);
     return this->m_isWhiteTurn ? rawEval : rawEval * -1;
 }
 

--- a/src/eval.cpp
+++ b/src/eval.cpp
@@ -29,7 +29,7 @@
 
 namespace Eval {
 
-int Info::getRawEval(const PieceSets& pieceSets) {
+int Info::getRawEval(const PieceSets& pieceSets, bool isWhiteTurn) {
     // positive values means white is winning, negative means black
     const S pawnScore = this->getPawnInfo(pieceSets).score;
     const S mobilityScore = evalMobilityScores(pieceSets, true) - evalMobilityScores(pieceSets, false);
@@ -38,7 +38,9 @@ int Info::getRawEval(const PieceSets& pieceSets) {
     const int op = totalScore.opScore;
     const int eg = totalScore.egScore;
     const int eval = (op * this->phase + eg * (TOTAL_PHASE - this->phase)) / TOTAL_PHASE;
-    return eval + evalMopUpScore(pieceSets, eval);
+
+    const int tempoBonus = isWhiteTurn ? tempo : -tempo;
+    return eval + evalMopUpScore(pieceSets, eval) + tempoBonus;
 }
 
 void Info::addPiece(Square square, pieceTypes piece) {

--- a/src/eval.cpp
+++ b/src/eval.cpp
@@ -33,14 +33,14 @@ int Info::getRawEval(const PieceSets& pieceSets, bool isWhiteTurn) {
     // positive values means white is winning, negative means black
     const S pawnScore = this->getPawnInfo(pieceSets).score;
     const S mobilityScore = evalMobilityScores(pieceSets, true) - evalMobilityScores(pieceSets, false);
-    const S totalScore = this->score + pawnScore + mobilityScore;
+    const S tempoBonus = isWhiteTurn ? tempo : -tempo;
+    const S totalScore = this->score + pawnScore + mobilityScore + tempoBonus;
 
     const int op = totalScore.opScore;
     const int eg = totalScore.egScore;
     const int eval = (op * this->phase + eg * (TOTAL_PHASE - this->phase)) / TOTAL_PHASE;
 
-    const int tempoBonus = isWhiteTurn ? tempo : -tempo;
-    return eval + evalMopUpScore(pieceSets, eval) + tempoBonus;
+    return eval + evalMopUpScore(pieceSets, eval);
 }
 
 void Info::addPiece(Square square, pieceTypes piece) {

--- a/src/eval.cpp
+++ b/src/eval.cpp
@@ -33,14 +33,14 @@ int Info::getRawEval(const PieceSets& pieceSets, bool isWhiteTurn) {
     // positive values means white is winning, negative means black
     const S pawnScore = this->getPawnInfo(pieceSets).score;
     const S mobilityScore = evalMobilityScores(pieceSets, true) - evalMobilityScores(pieceSets, false);
-    const S tempoBonus = isWhiteTurn ? tempo : -tempo;
-    const S totalScore = this->score + pawnScore + mobilityScore + tempoBonus;
+    const S totalScore = this->score + pawnScore + mobilityScore;
 
     const int op = totalScore.opScore;
     const int eg = totalScore.egScore;
     const int eval = (op * this->phase + eg * (TOTAL_PHASE - this->phase)) / TOTAL_PHASE;
 
-    return eval + evalMopUpScore(pieceSets, eval);
+    const int tempoBonus = isWhiteTurn ? tempo : -tempo;
+    return eval + evalMopUpScore(pieceSets, eval) + tempoBonus;
 }
 
 void Info::addPiece(Square square, pieceTypes piece) {

--- a/src/eval.hpp
+++ b/src/eval.hpp
@@ -76,7 +76,7 @@ struct PawnHashEntry {
 class Info {
     public:
         Info() = default;
-        int getRawEval(const PieceSets& pieceSets);
+        int getRawEval(const PieceSets& pieceSets, bool isWhiteTurn);
         void addPiece(Square square, pieceTypes piece);
         void removePiece(Square square, pieceTypes piece);
     private:
@@ -132,6 +132,7 @@ constexpr std::array<S, NUM_PIECES> pieceVals = {
 constexpr auto doubledPawns = S(-16,-33);
 constexpr auto chainedPawns = S( 23, 21);
 constexpr auto phalanxPawns = S( 10, 10);
+constexpr int tempo = 11;
 
 // piece square tables
 constexpr auto PSQT = [] {

--- a/src/eval.hpp
+++ b/src/eval.hpp
@@ -132,7 +132,7 @@ constexpr std::array<S, NUM_PIECES> pieceVals = {
 constexpr auto doubledPawns = S(-16,-33);
 constexpr auto chainedPawns = S( 23, 21);
 constexpr auto phalanxPawns = S( 10, 10);
-constexpr auto tempo = S();
+constexpr int tempo = 11;
 
 // piece square tables
 constexpr auto PSQT = [] {

--- a/src/eval.hpp
+++ b/src/eval.hpp
@@ -132,7 +132,7 @@ constexpr std::array<S, NUM_PIECES> pieceVals = {
 constexpr auto doubledPawns = S(-16,-33);
 constexpr auto chainedPawns = S( 23, 21);
 constexpr auto phalanxPawns = S( 10, 10);
-constexpr int tempo = 11;
+constexpr auto tempo = S();
 
 // piece square tables
 constexpr auto PSQT = [] {

--- a/tools/tune/texelBlocky.cpp
+++ b/tools/tune/texelBlocky.cpp
@@ -43,7 +43,6 @@ parameters_t BlockyEval::get_initial_parameters() {
     pushSingleTerm(params, "doubledPawns", Eval::doubledPawns);
     pushSingleTerm(params, "chainedPawns", Eval::chainedPawns);
     pushSingleTerm(params, "phalanxPawns", Eval::phalanxPawns);
-    pushSingleTerm(params, "tempo", Eval::tempo);
 
     totalSize = params.size();
     return params;
@@ -162,9 +161,6 @@ EvalResult BlockyEval::get_fen_eval_result(const std::string& fen) {
         result.coefficients[offsets["phalanxPawns"]] += phalanxPawnFlag * occurences;
         result.coefficients[mobilityOffset + mobility] += mobilityFlag * occurences;
     }
-
-    // misc terms
-    result.coefficients[offsets["tempo"]] += board.isWhiteTurn() ? 1 : -1;
 
     result.score = board.evaluate();
     return result;

--- a/tools/tune/texelBlocky.cpp
+++ b/tools/tune/texelBlocky.cpp
@@ -43,6 +43,7 @@ parameters_t BlockyEval::get_initial_parameters() {
     pushSingleTerm(params, "doubledPawns", Eval::doubledPawns);
     pushSingleTerm(params, "chainedPawns", Eval::chainedPawns);
     pushSingleTerm(params, "phalanxPawns", Eval::phalanxPawns);
+    pushSingleTerm(params, "tempo", Eval::tempo);
 
     totalSize = params.size();
     return params;
@@ -161,6 +162,9 @@ EvalResult BlockyEval::get_fen_eval_result(const std::string& fen) {
         result.coefficients[offsets["phalanxPawns"]] += phalanxPawnFlag * occurences;
         result.coefficients[mobilityOffset + mobility] += mobilityFlag * occurences;
     }
+
+    // misc terms
+    result.coefficients[offsets["tempo"]] += board.isWhiteTurn() ? 1 : -1;
 
     result.score = board.evaluate();
     return result;


### PR DESCRIPTION
A bonus is given for being the side to move. Attempts were made to tune a phased evaluation version, but they failed to fit to a meaningful value, likely due to the amount of noise in the dataset.

```
Advancement Test:
Time Control: 10s + 0.1s
LLR: 2.95 (-2.94, 2.94) [0.0, 8.0]
Games: N=1372 W=414 L=329 D=629
Elo: 21.6 +/- 13.5
Bench: 2182440
```