### PR TITLE
Define allPieces correctly in eval

### DIFF
--- a/src/eval.cpp
+++ b/src/eval.cpp
@@ -105,7 +105,7 @@ S evalPawns(const PieceSets& pieceSets, bool isWhite) {
 
 S evalPieces(const PieceSets& pieceSets, bool isWhite) {
     const uint64_t mobilitySquares = getMobilitySquares(pieceSets, isWhite);
-    const uint64_t allPieces   = isWhite ? pieceSets[WHITE_PIECES] : pieceSets[BLACK_PIECES];
+    const uint64_t allPieces = pieceSets[WHITE_PIECES] | pieceSets[BLACK_PIECES];
     uint64_t allyKnights = isWhite ? pieceSets[WKnight] : pieceSets[BKnight];
     uint64_t allyBishops = isWhite ? pieceSets[WBishop] : pieceSets[BBishop];
     uint64_t allyRooks = isWhite ? pieceSets[WRook] : pieceSets[BRook];

--- a/tools/tune/texelBlocky.cpp
+++ b/tools/tune/texelBlocky.cpp
@@ -89,7 +89,7 @@ void BlockyEval::pushEntry(parameters_t& parameters, Eval::S entry, const Eval::
 EvalResult BlockyEval::get_fen_eval_result(const std::string& fen) {
     Board board(fen);
     EvalResult result;
-    const auto allPieces = allPieces(board.pieceSets);
+    const auto allPieces = board.pieceSets[WHITE_PIECES] | board.pieceSets[BLACK_PIECES];
 
     /************
      * Initialize coefficients to zero-weights, which should fit most of them


### PR DESCRIPTION
```
Advancement Test:
Time Control: 8s + 0.08s
LLR: 2.96 (-2.94, 2.94) [0.0, 8.0]
Games: N=2041 W=600 L=522 D=919
Elo: 16.0 +/- 11.2
Bench: 1955409
```