### PR TITLE
Piecesets

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,6 +18,7 @@ target_sources(Blocky PRIVATE
     src/board.cpp
     src/moveGen.cpp
     src/moveOrder.cpp
+    src/pieceSets.cpp
     src/search.cpp
     src/ttable.cpp
     src/eval.cpp

--- a/src/board.cpp
+++ b/src/board.cpp
@@ -485,15 +485,15 @@ auto currKingInAttack(const PieceSets& pieceSets, bool isWhiteTurn) -> bool {
     const pieceTypes allyKing = isWhiteTurn ? WKing : BKing;
     assert(pieceSets[allyKing]);
     const int kingSquare = lsb(pieceSets[allyKing]);
+    const bool enemyColor = !isWhiteTurn;
 
-    const uint64_t allPieces = pieceSets.get(ALL);
-
-    const uint64_t enemyKings   = pieceSets.get(KING, !isWhiteTurn);
-    const uint64_t enemyQueens  = pieceSets.get(QUEEN, !isWhiteTurn);
-    const uint64_t enemyBishops = pieceSets.get(BISHOP, !isWhiteTurn);
-    const uint64_t enemyRooks   = pieceSets.get(ROOK, !isWhiteTurn);
-    const uint64_t enemyKnights = pieceSets.get(KNIGHT, !isWhiteTurn);
-    const uint64_t enemyPawns   = pieceSets.get(PAWN, !isWhiteTurn);
+    const uint64_t allPieces    = pieceSets.get(ALL);
+    const uint64_t enemyKings   = pieceSets.get(KING, enemyColor);
+    const uint64_t enemyQueens  = pieceSets.get(QUEEN, enemyColor);
+    const uint64_t enemyBishops = pieceSets.get(BISHOP, enemyColor);
+    const uint64_t enemyRooks   = pieceSets.get(ROOK, enemyColor);
+    const uint64_t enemyKnights = pieceSets.get(KNIGHT, enemyColor);
+    const uint64_t enemyPawns   = pieceSets.get(PAWN, enemyColor);
 
     return Attacks::bishopAttacks(kingSquare, allPieces) & (enemyBishops | enemyQueens)
         || Attacks::rookAttacks(kingSquare, allPieces) & (enemyRooks | enemyQueens)

--- a/src/board.cpp
+++ b/src/board.cpp
@@ -482,9 +482,9 @@ auto castleRightsBit(Square finalKingPos, bool m_isWhiteTurn) -> castleRights {
 }
 
 auto currKingInAttack(const PieceSets& pieceSets, bool isWhiteTurn) -> bool {
-    const pieceTypes allyKing = isWhiteTurn ? WKing : BKing;
-    assert(pieceSets[allyKing]);
-    const int kingSquare = lsb(pieceSets[allyKing]);
+    const uint64_t allyKing = pieceSets.get(KING, isWhiteTurn);
+    assert(allyKing);
+    const int kingSquare = lsb(allyKing);
     const bool enemyColor = !isWhiteTurn;
 
     const uint64_t allPieces    = pieceSets.get(ALL);

--- a/src/board.cpp
+++ b/src/board.cpp
@@ -24,6 +24,7 @@
 #include <stdlib.h>
 
 #include "board.hpp"
+#include "pieceSets.hpp"
 #include "move.hpp"
 #include "attacks.hpp"
 #include "bitboard.hpp"
@@ -485,14 +486,14 @@ auto currKingInAttack(const PieceSets& pieceSets, bool isWhiteTurn) -> bool {
     assert(pieceSets[allyKing]);
     const int kingSquare = lsb(pieceSets[allyKing]);
 
-    const uint64_t allPieces = pieceSets[WHITE_PIECES] | pieceSets[BLACK_PIECES];
+    const uint64_t allPieces = pieceSets.get(ALL);
 
-    const uint64_t enemyKings   = isWhiteTurn ? pieceSets[BKing]   : pieceSets[WKing];
-    const uint64_t enemyQueens  = isWhiteTurn ? pieceSets[BQueen]  : pieceSets[WQueen];
-    const uint64_t enemyBishops = isWhiteTurn ? pieceSets[BBishop] : pieceSets[WBishop];
-    const uint64_t enemyRooks   = isWhiteTurn ? pieceSets[BRook]   : pieceSets[WRook];
-    const uint64_t enemyKnights = isWhiteTurn ? pieceSets[BKnight] : pieceSets[WKnight];
-    const uint64_t enemyPawns   = isWhiteTurn ? pieceSets[BPawn]   : pieceSets[WPawn];
+    const uint64_t enemyKings   = pieceSets.get(KING, !isWhiteTurn);
+    const uint64_t enemyQueens  = pieceSets.get(QUEEN, !isWhiteTurn);
+    const uint64_t enemyBishops = pieceSets.get(BISHOP, !isWhiteTurn);
+    const uint64_t enemyRooks   = pieceSets.get(ROOK, !isWhiteTurn);
+    const uint64_t enemyKnights = pieceSets.get(KNIGHT, !isWhiteTurn);
+    const uint64_t enemyPawns   = pieceSets.get(PAWN, !isWhiteTurn);
 
     return Attacks::bishopAttacks(kingSquare, allPieces) & (enemyBishops | enemyQueens)
         || Attacks::rookAttacks(kingSquare, allPieces) & (enemyRooks | enemyQueens)

--- a/src/board.hpp
+++ b/src/board.hpp
@@ -23,6 +23,7 @@
 #include <vector>
 
 #include "eval.hpp"
+#include "pieceSets.hpp"
 #include "move.hpp"
 #include "bitboard.hpp"
 #include "utils/types.hpp"
@@ -94,21 +95,10 @@ class Board {
         std::vector<BoardState> m_moveHistory;
 };
 
-inline auto allPieces(const PieceSets& pieceSets) -> uint64_t {
-    return pieceSets[WHITE_PIECES] | pieceSets[BLACK_PIECES];
-}
-inline auto allPawns(const PieceSets& pieceSets) -> uint64_t {
-    return pieceSets[WPawn] | pieceSets[BPawn];
-}
-
-inline auto allKings(const PieceSets& pieceSets) -> uint64_t {
-    return pieceSets[WKing] | pieceSets[BKing];
-}
-
 inline auto Board::hasNonPawnMat() const -> bool {
-    const auto pieces = allPieces(this->pieceSets);
-    const auto pawns = allPawns(this->pieceSets);
-    const auto kings = allKings(this->pieceSets);
+    const auto pieces = this->pieceSets.get(ALL);
+    const auto pawns = this->pieceSets.get(PAWN);
+    const auto kings = this->pieceSets.get(KING);
     return static_cast<bool>(pieces ^ (pawns | kings));
 }
 

--- a/src/eval.hpp
+++ b/src/eval.hpp
@@ -18,6 +18,7 @@
 
 #pragma once
 
+#include "pieceSets.hpp"
 #include "move.hpp"
 #include "bitboard.hpp"
 #include "utils/types.hpp"

--- a/src/moveGen.cpp
+++ b/src/moveGen.cpp
@@ -26,18 +26,18 @@
 
 MoveList::MoveList(const Board& board) {
     // information used in both captures and quiets move generation
-    this->allPieces = board.pieceSets[WHITE_PIECES] | board.pieceSets[BLACK_PIECES];
+    this->allPieces = board.pieceSets.get(ALL);
     this->emptySquares = ~this->allPieces;
     this->isWhiteTurn = board.isWhiteTurn();
 
     // gather piece bitboards
-    this->kings   = board.isWhiteTurn() ? board.pieceSets[WKing]   : board.pieceSets[BKing];
-    this->knights = board.isWhiteTurn() ? board.pieceSets[WKnight] : board.pieceSets[BKnight];
-    this->bishops = board.isWhiteTurn() ? board.pieceSets[WBishop] : board.pieceSets[BBishop];
-    this->rooks   = board.isWhiteTurn() ? board.pieceSets[WRook]   : board.pieceSets[BRook];
-    this->queens  = board.isWhiteTurn() ? board.pieceSets[WQueen]  : board.pieceSets[BQueen];
+    this->kings   = board.pieceSets.get(KING, board.isWhiteTurn());
+    this->knights = board.pieceSets.get(KNIGHT, board.isWhiteTurn());
+    this->bishops = board.pieceSets.get(BISHOP, board.isWhiteTurn());
+    this->rooks   = board.pieceSets.get(ROOK, board.isWhiteTurn());
+    this->queens  = board.pieceSets.get(QUEEN, board.isWhiteTurn());
     
-    this->pawns   = board.isWhiteTurn() ? board.pieceSets[WPawn]   : board.pieceSets[BPawn];
+    this->pawns   = board.pieceSets.get(PAWN, board.isWhiteTurn());
     this->promotingPawns = board.isWhiteTurn() ? this->pawns & RANK_7 : this->pawns & RANK_2;
     this->pawns ^= promotingPawns;
 }
@@ -49,7 +49,7 @@ void MoveList::generateAllMoves(const Board& board) {
 
 void MoveList::generateCaptures(const Board& board) {
     // helper information for captures
-    uint64_t validDests = this->isWhiteTurn ? board.pieceSets[BLACK_PIECES] : board.pieceSets[WHITE_PIECES];
+    uint64_t validDests = board.pieceSets.get(ALL, !isWhiteTurn);
     this->enPassSquare = board.enPassSquare();
 
     const auto knightMovesFunc = [this](Square piece, uint64_t vd) {return this->knightMoves(piece, vd);};

--- a/src/pieceSets.cpp
+++ b/src/pieceSets.cpp
@@ -1,0 +1,47 @@
+#include <cassert>
+
+#include "pieceSets.hpp"
+
+auto PieceSets::get(pieceTypes piece) const -> uint64_t {
+    switch (piece)
+    {
+    case KING:
+        return this->data[WKing] | this->data[BKing];
+    case KNIGHT:
+        return this->data[WKnight] | this->data[BKnight];
+    case BISHOP:
+        return this->data[WBishop] | this->data[BBishop];
+    case ROOK:
+        return this->data[WRook] | this->data[BRook];
+    case QUEEN:
+        return this->data[WQueen] | this->data[BQueen];
+    case PAWN:
+        return this->data[WPawn] | this->data[BPawn];
+    case ALL:
+        return this->data[WHITE_PIECES] | this->data[BLACK_PIECES];
+    default:
+        assert(false);
+    }
+}
+
+auto PieceSets::get(pieceTypes piece, bool isWhite) const -> uint64_t {
+    switch (piece)
+    {
+    case KING:
+        return isWhite ? this->data[WKing] : this->data[BKing];
+    case KNIGHT:
+        return isWhite ? this->data[WKnight] : this->data[BKnight];
+    case BISHOP:
+        return isWhite ? this->data[WBishop] : this->data[BBishop];
+    case ROOK:
+        return isWhite ? this->data[WRook] : this->data[BRook];
+    case QUEEN:
+        return isWhite ? this->data[WQueen] : this->data[BQueen];
+    case PAWN:
+        return isWhite ? this->data[WPawn] : this->data[BPawn];
+    case ALL:
+        return isWhite ? this->data[WHITE_PIECES] : this->data[BLACK_PIECES];
+    default:
+        assert(false);
+    }
+}

--- a/src/pieceSets.cpp
+++ b/src/pieceSets.cpp
@@ -24,7 +24,7 @@ auto PieceSets::get(pieceTypes piece) const -> uint64_t {
     }
 }
 
-auto PieceSets::get(pieceTypes piece, bool isWhite) const -> uint64_t {
+auto PieceSets::get(pieceTypes piece, bool isWhite) const -> const uint64_t& {
     switch (piece)
     {
     case KING:

--- a/src/pieceSets.hpp
+++ b/src/pieceSets.hpp
@@ -1,0 +1,37 @@
+#pragma once
+
+#include <array>
+#include <cstdint>
+
+#include "utils/types.hpp"
+
+class PieceSets {
+    public:
+        auto get(pieceTypes piece) const -> uint64_t;
+        auto get(pieceTypes piece, bool isWhite) const -> uint64_t;
+
+        auto view() const -> const std::array<uint64_t, NUM_BITBOARDS>&;
+
+        auto operator[](std::size_t index) -> uint64_t&;
+        auto operator[](std::size_t index) const -> const uint64_t&;
+        auto operator==(const PieceSets& rhs) const -> bool;
+    private:
+        std::array<uint64_t, NUM_BITBOARDS> data;
+};
+
+
+inline auto PieceSets::view() const -> const std::array<uint64_t, NUM_BITBOARDS>& {
+    return this->data;
+}
+
+inline auto PieceSets::operator[](std::size_t index) -> uint64_t& {
+    return this->data[index];
+}
+
+inline auto PieceSets::operator[](std::size_t index) const -> const uint64_t& {
+    return this->data[index];
+}
+
+inline auto PieceSets::operator==(const PieceSets& rhs) const -> bool {
+    return this->view() == rhs.view();
+}

--- a/src/pieceSets.hpp
+++ b/src/pieceSets.hpp
@@ -8,7 +8,7 @@
 class PieceSets {
     public:
         auto get(pieceTypes piece) const -> uint64_t;
-        auto get(pieceTypes piece, bool isWhite) const -> uint64_t;
+        auto get(pieceTypes piece, bool isWhite) const -> const uint64_t&;
 
         auto view() const -> const std::array<uint64_t, NUM_BITBOARDS>&;
 

--- a/src/utils/types.hpp
+++ b/src/utils/types.hpp
@@ -32,7 +32,6 @@ inline constexpr int MAX_MOVES = 256;
 inline constexpr int MAX_PLY = 250;
 
 using Square = uint8_t;
-using PieceSets = std::array<uint64_t, NUM_BITBOARDS>;
 using HistoryTable = std::array<std::array<int, BOARD_SIZE>, BOARD_SIZE>;
 using RNGSeed = std::array<uint64_t, 4>;
 
@@ -50,7 +49,7 @@ enum pieceTypes: int {
     BKing, BQueen, BBishop, BKnight, BRook, BPawn,
     WHITE_PIECES, BLACK_PIECES,
 
-    KING = WKing, KNIGHT = WKnight, BISHOP = WBishop, ROOK = WRook, QUEEN = WQueen, PAWN = WPawn
+    KING = WKing, KNIGHT = WKnight, BISHOP = WBishop, ROOK = WRook, QUEEN = WQueen, PAWN = WPawn, ALL = WHITE_PIECES
 };
 
 // indices are equal to the enumerated pieceTypes

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -27,6 +27,7 @@ add_executable(allTests
     ../src/board.cpp
     ../src/moveGen.cpp
     ../src/moveOrder.cpp
+    ../src/pieceSets.cpp
     ../src/timeman.cpp
     ../src/ttable.cpp
     ../src/search.cpp

--- a/tests/testEval.cpp
+++ b/tests/testEval.cpp
@@ -105,7 +105,7 @@ TEST_F(EvalTest, bishopMobilityBlack) {
     const Board pos("rnbqk2r/pppp1ppp/5n2/4p3/1b1NP3/8/PPPP1PPP/RNBQKB1R w KQkq - 1 4");
     const Square sq = toSquare("b4");
     const auto mobilitySquares = getMobilitySquares(pos.pieceSets, false);
-    const auto allPieces = allPieces(pos.pieceSets);
+    const auto allPieces = pos.pieceSets.get(ALL);
     const auto mobility = getPieceMobility(BISHOP, sq, mobilitySquares, allPieces);
     ASSERT_EQ(mobility, 6);
 }

--- a/tools/tune/CMakeLists.txt
+++ b/tools/tune/CMakeLists.txt
@@ -8,6 +8,7 @@ target_sources(extract PRIVATE
     ../../src/moveGen.cpp
     ../../src/board.cpp
     ../../src/move.cpp
+    ../../src/pieceSets.cpp
     ../../src/eval.cpp
     ../../src/attacks.cpp
     ../../src/bitboard.cpp

--- a/tools/tune/extract.cpp
+++ b/tools/tune/extract.cpp
@@ -326,8 +326,7 @@ void storeFenResults(std::ofstream& file, std::vector<std::string> fens, Winning
         Board board(fen);
 
         // filter unwanted positions
-        uint64_t nonPawns = board.pieceSets[WHITE_PIECES] | board.pieceSets[BLACK_PIECES];
-        nonPawns ^= board.pieceSets[WPawn] | board.pieceSets[BPawn];
+        uint64_t nonPawns = board.pieceSets.get(ALL) ^ board.pieceSets.get(PAWN);
         if (popcount(nonPawns) <= 4) {
             continue;
         }

--- a/tools/tune/texelBlocky.cpp
+++ b/tools/tune/texelBlocky.cpp
@@ -114,8 +114,8 @@ EvalResult BlockyEval::get_fen_eval_result(const std::string& fen) {
         // pawn terms
         int passedPawnFlag = 0, doubledPawnFlag = 0, chainedPawnFlag = 0, phalanxPawnFlag = 0;
         if (colorlessPiece == WPawn) {
-            const uint64_t allyPawnSet = isWhitePiece ? board.pieceSets[WPawn] : board.pieceSets[BPawn];
-            const uint64_t enemyPawnSet = isWhitePiece ? board.pieceSets[BPawn] : board.pieceSets[WPawn];
+            const uint64_t allyPawnSet = board.pieceSets.get(PAWN, isWhitePiece);
+            const uint64_t enemyPawnSet = board.pieceSets.get(PAWN, !isWhitePiece);
             const uint64_t doubledPawnSet = Eval::getDoubledPawnsMask(allyPawnSet, isWhitePiece);
             const uint64_t chainedPawnSet = Eval::getChainedPawnsMask(allyPawnSet, isWhitePiece);
             const uint64_t phalanxPawnSet = Eval::getPhalanxPawnsMask(allyPawnSet);
@@ -164,7 +164,8 @@ EvalResult BlockyEval::get_fen_eval_result(const std::string& fen) {
     }
 
     // misc coefficients
-    int bishopPairFlag = Eval::isBishopPair(board.pieceSets[WBishop]) - Eval::isBishopPair(board.pieceSets[BBishop]);
+    int bishopPairFlag = Eval::isBishopPair(board.pieceSets.get(BISHOP, true)) - 
+                         Eval::isBishopPair(board.pieceSets.get(BISHOP, false));
     result.coefficients[offsets["bishopPair"]] += bishopPairFlag;
 
     result.score = board.evaluate();

--- a/tools/tune/texelBlocky.cpp
+++ b/tools/tune/texelBlocky.cpp
@@ -89,7 +89,7 @@ void BlockyEval::pushEntry(parameters_t& parameters, Eval::S entry, const Eval::
 EvalResult BlockyEval::get_fen_eval_result(const std::string& fen) {
     Board board(fen);
     EvalResult result;
-    const auto allPieces = board.pieceSets[WHITE_PIECES] | board.pieceSets[BLACK_PIECES];
+    const auto allPieces = board.pieceSets.get(ALL);
 
     /************
      * Initialize coefficients to zero-weights, which should fit most of them


### PR DESCRIPTION
This abstracts away some common usages of bit manipulations with PieceSets. A future goal may be to completely remove [] accesses to PieceSets externally like what Board and MoveGen still do.

```
Regression Test:
Time Control: 8s + 0.08s
LLR: 2.96 (-2.94, 2.94) [-8.0, 0.0]
Games: N=3941 W=1045 L=1023 D=1873
Elo: 1.9 +/- 7.8
Bench: 1955409
```
