### PR TITLE
Internal Iterative Reductions

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -124,6 +124,7 @@ int Searcher::aspiration(int depth, int prevEval) {
 
 template <NodeTypes NODE>
 int Searcher::search(int alpha, int beta, int depth, StackEntry* ss) {
+    constexpr bool ISROOT = NODE == ROOT;
     constexpr bool ISPV = NODE == ROOT || NODE == PV;
     constexpr bool ISNMP = NODE == NMP;
     const int oldAlpha = alpha;
@@ -165,6 +166,14 @@ int Searcher::search(int alpha, int beta, int depth, StackEntry* ss) {
         staticEval = entry.eval;
     } else {
         staticEval = this->board.evaluate();
+    }
+
+    /************
+     * Internal Iterative Reductions
+     * Nodes that don't have a TTMove are less likely to be important
+    *************/
+    if (!ISROOT && !TTMove && depth >= 6) {
+        depth--;
     }
 
     /************


### PR DESCRIPTION
Positions that don't have a TTMove saved typically are searched less and are less important to search deeply.

```
Advancement Test:
Time Control: 8s + 0.08s
LLR: 2.97 (-2.94, 2.94) [0.0, 8.0]
Games: N=1570 W=438 L=355 D=777
Elo: 18.4 +/- 12.2
Bench: 1614331
```
