### PR TITLE
Simplify "age"

### DIFF
--- a/src/board.cpp
+++ b/src/board.cpp
@@ -245,7 +245,6 @@ void Board::makeMove(Move move) {
     // after finalizing move logic, now switch turns
     this->m_isWhiteTurn = !this->m_isWhiteTurn;
     this->m_zobristKey ^= Zobrist::isBlackKey;
-    this->m_age++;
 
     // update history to include curr key
     this->m_zobristKeyHistory.push_back(this->m_zobristKey);
@@ -281,7 +280,6 @@ void Board::undoMove() {
     this->m_castlingRights = prev.castlingRights;
     this->m_enPassSquare = prev.enPassSquare;
     this->m_fiftyMoveRule = prev.fiftyMoveRule;
-    this->m_age--;
 
     this->m_moveHistory.pop_back();
     this->m_zobristKeyHistory.pop_back();
@@ -303,7 +301,6 @@ void Board::makeNullMove() {
     }
     this->m_isWhiteTurn = !this->m_isWhiteTurn;
     this->m_fiftyMoveRule++;
-    this->m_age++;
 
     this->m_zobristKey ^= Zobrist::isBlackKey;
     this->m_zobristKeyHistory.push_back(this->m_zobristKey);
@@ -313,7 +310,6 @@ void Board::unmakeNullMove() {
     this->m_enPassSquare = this->m_moveHistory.back().enPassSquare;
     this->m_isWhiteTurn = !this->m_isWhiteTurn;
     this->m_fiftyMoveRule--;
-    this->m_age--;
 
     this->m_moveHistory.pop_back();
     this->m_zobristKeyHistory.pop_back();

--- a/src/board.hpp
+++ b/src/board.hpp
@@ -72,7 +72,6 @@ class Board {
         auto castlingRights() const -> castleRights;
         auto enPassSquare() const -> Square;
         auto fiftyMoveRule() const -> int;
-        auto age() const -> int;
         auto zobristKey() const -> uint64_t;
 
         auto operator==(const Board& rhs) const -> bool;
@@ -89,7 +88,6 @@ class Board {
         castleRights m_castlingRights;
         Square m_enPassSquare;
         int m_fiftyMoveRule;
-        int m_age = 0;
         uint64_t m_zobristKey; // zobristKeyHistory also contains zobristKey
         std::vector<uint64_t> m_zobristKeyHistory;
         std::vector<BoardState> m_moveHistory;
@@ -120,10 +118,6 @@ inline auto Board::enPassSquare() const -> Square {
 
 inline auto Board::fiftyMoveRule() const -> int {
     return this->m_fiftyMoveRule;
-}
-
-inline auto Board::age() const -> int {
-    return this->m_age;
 }
 
 inline auto Board::zobristKey() const -> uint64_t {

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -344,7 +344,7 @@ int Searcher::search(int alpha, int beta, int depth, StackEntry* ss) {
     // store results with best moves in transposition table
     if (bestMove) {
         const EvalType bound = (bestscore >= beta) ? EvalType::LOWER : (alpha == oldAlpha) ? EvalType::UPPER : EvalType::EXACT;
-        TTable::Table.store(bestscore, bestMove, bound, depth, this->board.age(), this->board.zobristKey());
+        TTable::Table.store(bestscore, bestMove, bound, depth, this->board.zobristKey());
     }
     return bestscore;
 }

--- a/src/ttable.cpp
+++ b/src/ttable.cpp
@@ -59,22 +59,14 @@ Entry TTable::getEntry(uint64_t key) const {
     return this->table[this->getIndex(key)];
 }
 
-void TTable::store(int eval, Move move, EvalType bound, int depth, int age, uint64_t key) {
-    /* entries in the transposition table are overwritten under two conditions:
-    1. The current search depth is greater than the entry's depth, meaning that a better
-    search has been performed
-    2. The age of the current position is greater than the previous age. Previous move searches
-    in hash are preserved in the table since there can be repeated boards, but replacing entries
-    with moves from more modern roots is better
-    */
-    Entry* entry = &this->table[this->getIndex(key)];
+void TTable::store(int eval, Move move, EvalType bound, int depth, uint64_t key) {
+    Entry& entry = this->table[this->getIndex(key)];
     if (true) {
-        entry->eval = eval;
-        entry->move = move;
-        entry->bound = bound;
-        entry->depth = depth;
-        entry->age = age;
-        entry->key = key;
+        entry.eval = eval;
+        entry.move = move;
+        entry.bound = bound;
+        entry.depth = depth;
+        entry.key = key;
     }
 }
 

--- a/src/ttable.hpp
+++ b/src/ttable.hpp
@@ -30,7 +30,6 @@ inline constexpr int DEFAULT_SIZEMB = 128;
 
 struct Entry {
     uint64_t key{};
-    uint8_t age{};
     int depth{};
     int eval{};
     EvalType bound = NONE;
@@ -46,7 +45,7 @@ class TTable {
 
         bool entryExists(uint64_t key) const;
         Entry getEntry(uint64_t key) const;
-        void store(int eval, Move move, EvalType bound, int depth, int age, uint64_t key);
+        void store(int eval, Move move, EvalType bound, int depth, uint64_t key);
         void prefetch(uint64_t key) const;
     private:
         int getIndex(uint64_t key) const;


### PR DESCRIPTION
This was never was the colloquial version of age in chess programming. Since always replace is used, "age" can be removed.

```
Regression Test:
Time Control: 8s + 0.08s
LLR: 2.98 (-2.94, 2.94) [-8.0, 0.0]
Games: N=2013 W=586 L=537 D=890
Elo: 8.5 +/- 11.3
Bench: 1693445
```
